### PR TITLE
Rename to yubikey.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `MgmKey::set` method ([#224])
 
-[#223]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/223
-[#224]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/224
+[#223]: https://github.com/iqlusioninc/yubikey.rs/pull/223
+[#224]: https://github.com/iqlusioninc/yubikey.rs/pull/224
 
 ## 0.2.0 (2021-01-30)
 ### Changed
@@ -27,10 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump MSRV to 1.46+ ([#208])
 - Bump `pbkdf2` dependency to v0.7 ([#219])
 
-[#194]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/194
-[#207]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/207
-[#208]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/208
-[#219]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/219
+[#194]: https://github.com/iqlusioninc/yubikey.rs/pull/194
+[#207]: https://github.com/iqlusioninc/yubikey.rs/pull/207
+[#208]: https://github.com/iqlusioninc/yubikey.rs/pull/208
+[#219]: https://github.com/iqlusioninc/yubikey.rs/pull/219
 
 ## 0.1.0 (2020-10-19)
 ### Added
@@ -57,22 +57,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - YubiKey NEO support ([#63])
 
-[#177]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/177
-[#175]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/175
-[#128]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/128
-[#82]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/82
-[#73]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/73
-[#88]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/88
-[#80]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/80
-[#69]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/69
-[#68]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/68
-[#67]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/67
-[#65]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/65
-[#64]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/64
-[#63]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/63
-[#62]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/62
-[#61]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/61
-[#60]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/60
+[#177]: https://github.com/iqlusioninc/yubikey.rs/pull/177
+[#175]: https://github.com/iqlusioninc/yubikey.rs/pull/175
+[#128]: https://github.com/iqlusioninc/yubikey.rs/pull/128
+[#82]: https://github.com/iqlusioninc/yubikey.rs/pull/82
+[#73]: https://github.com/iqlusioninc/yubikey.rs/pull/73
+[#88]: https://github.com/iqlusioninc/yubikey.rs/pull/88
+[#80]: https://github.com/iqlusioninc/yubikey.rs/pull/80
+[#69]: https://github.com/iqlusioninc/yubikey.rs/pull/69
+[#68]: https://github.com/iqlusioninc/yubikey.rs/pull/68
+[#67]: https://github.com/iqlusioninc/yubikey.rs/pull/67
+[#65]: https://github.com/iqlusioninc/yubikey.rs/pull/65
+[#64]: https://github.com/iqlusioninc/yubikey.rs/pull/64
+[#63]: https://github.com/iqlusioninc/yubikey.rs/pull/63
+[#62]: https://github.com/iqlusioninc/yubikey.rs/pull/62
+[#61]: https://github.com/iqlusioninc/yubikey.rs/pull/61
+[#60]: https://github.com/iqlusioninc/yubikey.rs/pull/60
 
 ## 0.0.3 (2019-12-02)
 ### Added
@@ -90,17 +90,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Ins` (APDU instruction codes) enum ([#33])
 - Factor `Response` into `apdu` module; improved debugging ([#32])
 
-[#51]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/51
-[#45]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/45
-[#44]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/44
-[#43]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/43
-[#42]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/42
-[#39]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/39
-[#37]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/37
-[#36]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/36
-[#34]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/34
-[#33]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/33
-[#32]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/32
+[#51]: https://github.com/iqlusioninc/yubikey.rs/pull/51
+[#45]: https://github.com/iqlusioninc/yubikey.rs/pull/45
+[#44]: https://github.com/iqlusioninc/yubikey.rs/pull/44
+[#43]: https://github.com/iqlusioninc/yubikey.rs/pull/43
+[#42]: https://github.com/iqlusioninc/yubikey.rs/pull/42
+[#39]: https://github.com/iqlusioninc/yubikey.rs/pull/39
+[#37]: https://github.com/iqlusioninc/yubikey.rs/pull/37
+[#36]: https://github.com/iqlusioninc/yubikey.rs/pull/36
+[#34]: https://github.com/iqlusioninc/yubikey.rs/pull/34
+[#33]: https://github.com/iqlusioninc/yubikey.rs/pull/33
+[#32]: https://github.com/iqlusioninc/yubikey.rs/pull/32
 
 ## 0.0.2 (2019-11-25)
 ### Added
@@ -117,16 +117,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `log` crate for logging ([#7])
 - Replace `ErrorKind::Ok` with `Result` ([#6])
 
-[#30]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/30
-[#19]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/19
-[#17]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/17
-[#15]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/15
-[#13]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/13
-[#10]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/10
-[#9]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/9
-[#8]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/8
-[#7]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/7
-[#6]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/6
+[#30]: https://github.com/iqlusioninc/yubikey.rs/pull/30
+[#19]: https://github.com/iqlusioninc/yubikey.rs/pull/19
+[#17]: https://github.com/iqlusioninc/yubikey.rs/pull/17
+[#15]: https://github.com/iqlusioninc/yubikey.rs/pull/15
+[#13]: https://github.com/iqlusioninc/yubikey.rs/pull/13
+[#10]: https://github.com/iqlusioninc/yubikey.rs/pull/10
+[#9]: https://github.com/iqlusioninc/yubikey.rs/pull/9
+[#8]: https://github.com/iqlusioninc/yubikey.rs/pull/8
+[#7]: https://github.com/iqlusioninc/yubikey.rs/pull/7
+[#6]: https://github.com/iqlusioninc/yubikey.rs/pull/6
 
 ## 0.0.1 (2019-11-18)
 - Initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byteorder"
@@ -99,9 +99,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
@@ -145,9 +145,9 @@ checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.1"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec1028182c380cc45a2e2c5ec841134f2dfd0f8f5f0a5bcd68004f81b5efdf4"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
@@ -170,9 +170,9 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "der"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83dc83d0b59f92103d8e661e60526338ad3aeb0c15fa4a29a14b6a9b1ac8a43c"
+checksum = "2eeb9d92785d1facb50567852ce75d0858630630e7eabea59cf7eb7474051087"
 dependencies = [
  "const-oid",
  "typenum",
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b568b5e72165dd8913ac2aad6a60cb9cb297287615544c523c37f9247b58fc8"
+checksum = "34d33b390ab82f2e1481e331dbd0530895640179d2128ef9a79cc690b78d1eba"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee681bf25de1aad7cd02ccc7525d7b4bfab7be2493dbe3ee18d93f86eb3dcf3e"
+checksum = "c13e9b0c3c4170dcc2a12783746c4205d98e18957f57854251eea3f9750fe005"
 dependencies = [
  "bitvec 0.20.4",
  "ff",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime",
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libm"
@@ -423,15 +423,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "nom"
-version = "6.1.2"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
 dependencies = [
  "bitvec 0.19.5",
  "funty",
@@ -503,18 +503,18 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2508c8f170e55be68508b1113956a760a82684f42022f8834fb16ca198621211"
+checksum = "54815ff10e7c65c9b149e677ac20aeaa84e87b3bbcf0bdb5ab0355c568ab47c1"
 dependencies = [
  "der-parser",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "pcsc"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e09a8d8705a2c9b1ffe1f9dd9580efe3f8e80c19fc9f99038fe99b7bb56c83"
+checksum = "d4c82dbce82470474aa850ad01eb104c1b4b06d89ba831ab369f884a8610db18"
 dependencies = [
  "bitflags",
  "pcsc-sys",
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b813f58dc6e5d1820868a3c3df3a7ae7852aa2d3d18e98f0d6b20ddd01fe25d7"
+checksum = "c9c2f795bc591cb3384cb64082a578b89207ac92bb89c9d98c1ea2ace7cd8110"
 dependencies = [
  "der",
  "spki",
@@ -605,9 +605,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -635,9 +635,9 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -647,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -657,27 +657,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -727,18 +727,18 @@ dependencies = [
 
 [[package]]
 name = "rusticata-macros"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7390af60e66c44130b4c5ea85f2555b7ace835d73b4b889c704dc3cb4c0468c8"
+checksum = "d8db3e42c9a4a9479e121c66d4925d15a87734f6fa37f1df0434708718d316ce"
 dependencies = [
  "nom",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 
 [[package]]
 name = "sha-1"
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
  "rand_core",
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "simple_asn1"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0e9076e5242ff5a58e854cb478ea9caebce01088f86d3d9c6ad336b7655263"
+checksum = "8eb4ea60fb301dc81dfc113df680571045d375ab7345d171c5dc7d7e13107a80"
 dependencies = [
  "chrono",
  "num-bigint",
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -891,18 +891,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1085,23 +1085,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "yubikey-cli"
-version = "0.3.0"
-dependencies = [
- "env_logger",
- "gumdrop",
- "lazy_static",
- "log",
- "sha2",
- "subtle-encoding",
- "termcolor",
- "x509-parser",
- "yubikey-piv",
-]
-
-[[package]]
-name = "yubikey-piv"
-version = "0.3.0"
+name = "yubikey"
+version = "0.4.0-pre"
 dependencies = [
  "chrono",
  "cookie-factory",
@@ -1131,6 +1116,21 @@ dependencies = [
  "x509",
  "x509-parser",
  "zeroize",
+]
+
+[[package]]
+name = "yubikey-cli"
+version = "0.3.0"
+dependencies = [
+ "env_logger",
+ "gumdrop",
+ "lazy_static",
+ "log",
+ "sha2",
+ "subtle-encoding",
+ "termcolor",
+ "x509-parser",
+ "yubikey",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name    = "yubikey-piv"
-version = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+name    = "yubikey"
+version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust host-side driver for the YubiKey Personal Identity Verification (PIV)
 application providing general-purpose public-key signing and encryption
@@ -10,7 +10,7 @@ algorithms (e.g, PKCS#1v1.5, ECDSA)
 authors    = ["Tony Arcieri <tony@iqlusion.io>", "Yubico AB"]
 edition    = "2018"
 license    = "BSD-2-Clause"
-repository = "https://github.com/iqlusioninc/yubikey-piv.rs"
+repository = "https://github.com/iqlusioninc/yubikey.rs"
 readme     = "README.md"
 categories = ["api-bindings", "cryptography", "hardware-support"]
 keywords   = ["ecdsa", "rsa", "piv", "pcsc", "yubikey"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<img src="https://raw.githubusercontent.com/iqlusioninc/yubikey-piv.rs/main/img/logo.png" width="150" height="110">
+<img src="https://raw.githubusercontent.com/iqlusioninc/yubikey.rs/main/img/logo.png" width="150" height="110">
 
-# yubikey-piv.rs
+# yubikey.rs
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
@@ -147,7 +147,7 @@ For more information, please see [CODE_OF_CONDUCT.md][cc-md].
 
 ## License
 
-**yubikey-piv.rs** is a fork of and originally a mechanical translation from
+**yubikey.rs** is a fork of and originally a mechanical translation from
 Yubico's [yubico-piv-tool], a C library/CLI program. The original library
 was licensed under a [2-Clause BSD License][BSDL], which this library inherits
 as a derived work.
@@ -188,18 +188,18 @@ or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/yubikey-piv.svg
-[crate-link]: https://crates.io/crates/yubikey-piv
-[docs-image]: https://docs.rs/yubikey-piv/badge.svg
-[docs-link]: https://docs.rs/yubikey-piv/
+[crate-image]: https://img.shields.io/crates/v/yubikey.svg
+[crate-link]: https://crates.io/crates/yubikey
+[docs-image]: https://docs.rs/yubikey/badge.svg
+[docs-link]: https://docs.rs/yubikey/
 [license-image]: https://img.shields.io/badge/license-BSD-blue.svg
-[license-link]: https://github.com/iqlusioninc/yubikey-piv.rs/blob/main/COPYING
+[license-link]: https://github.com/iqlusioninc/yubikey.rs/blob/main/COPYING
 [rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
 [maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
-[build-image]: https://github.com/iqlusioninc/yubikey-piv.rs/workflows/CI/badge.svg?branch=main&event=push
-[build-link]: https://github.com/iqlusioninc/yubikey-piv.rs/actions
+[build-image]: https://github.com/iqlusioninc/yubikey.rs/workflows/CI/badge.svg?branch=main&event=push
+[build-link]: https://github.com/iqlusioninc/yubikey.rs/actions
 [gitter-image]: https://badges.gitter.im/badge.svg
 [gitter-link]: https://gitter.im/iqlusioninc/community
 
@@ -214,18 +214,18 @@ or conditions.
 [yubico-piv-tool]: https://github.com/Yubico/yubico-piv-tool/
 [Corrode]: https://github.com/jameysharp/corrode
 [cc-web]: https://contributor-covenant.org/
-[cc-md]: https://github.com/iqlusioninc/yubikey-piv.rs/blob/main/CODE_OF_CONDUCT.md
+[cc-md]: https://github.com/iqlusioninc/yubikey.rs/blob/main/CODE_OF_CONDUCT.md
 [BSDL]: https://opensource.org/licenses/BSD-2-Clause
 
 [//]: # (github issues)
 
-[#18]: https://github.com/iqlusioninc/yubikey-piv.rs/issues/18
-[#20]: https://github.com/iqlusioninc/yubikey-piv.rs/issues/20
-[#21]: https://github.com/iqlusioninc/yubikey-piv.rs/issues/21
-[#22]: https://github.com/iqlusioninc/yubikey-piv.rs/issues/22
-[#23]: https://github.com/iqlusioninc/yubikey-piv.rs/issues/23
-[#24]: https://github.com/iqlusioninc/yubikey-piv.rs/issues/24
-[#25]: https://github.com/iqlusioninc/yubikey-piv.rs/issues/25
-[#26]: https://github.com/iqlusioninc/yubikey-piv.rs/issues/26
-[#27]: https://github.com/iqlusioninc/yubikey-piv.rs/issues/27
-[#28]: https://github.com/iqlusioninc/yubikey-piv.rs/issues/28
+[#18]: https://github.com/iqlusioninc/yubikey.rs/issues/18
+[#20]: https://github.com/iqlusioninc/yubikey.rs/issues/20
+[#21]: https://github.com/iqlusioninc/yubikey.rs/issues/21
+[#22]: https://github.com/iqlusioninc/yubikey.rs/issues/22
+[#23]: https://github.com/iqlusioninc/yubikey.rs/issues/23
+[#24]: https://github.com/iqlusioninc/yubikey.rs/issues/24
+[#25]: https://github.com/iqlusioninc/yubikey.rs/issues/25
+[#26]: https://github.com/iqlusioninc/yubikey.rs/issues/26
+[#27]: https://github.com/iqlusioninc/yubikey.rs/issues/27
+[#28]: https://github.com/iqlusioninc/yubikey.rs/issues/28

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,34 +6,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.3.0 (2021-03-22)
 ### Changed
-- Bump `yubikey-piv` dependency to v0.3 ([#240])
+- Bump `yubikey` dependency to v0.3 ([#240])
 
-[#240]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/240
+[#240]: https://github.com/iqlusioninc/yubikey.rs/pull/240
 
 ## 0.2.0 (2021-01-30)
 ### Changed
 - Bump MSRV to 1.46+ ([#208])
-- Bump `yubikey-piv` dependency to v0.2 ([#220])
+- Bump `yubikey` dependency to v0.2 ([#220])
 
-[#208]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/208
-[#220]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/220
+[#208]: https://github.com/iqlusioninc/yubikey.rs/pull/208
+[#220]: https://github.com/iqlusioninc/yubikey.rs/pull/220
 
 ## 0.1.0 (2020-10-19)
 ### Added
 - `status` command ([#72], [#74])
 
 ### Changed
-- Bump `yubikey-piv` to v0.1.0 ([#180])
+- Bump `yubikey` to v0.1.0 ([#180])
 - Bump `x509-parser` to v0.8 ([#181])
 - Bump `sha2` to v0.9 ([#182])
 - Rename `list` command to `readers`; improve usage ([#71])
 
-[#182]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/182
-[#181]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/181
-[#180]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/180
-[#74]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/74
-[#72]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/72
-[#71]: https://github.com/iqlusioninc/yubikey-piv.rs/pull/71
+[#182]: https://github.com/iqlusioninc/yubikey.rs/pull/182
+[#181]: https://github.com/iqlusioninc/yubikey.rs/pull/181
+[#180]: https://github.com/iqlusioninc/yubikey.rs/pull/180
+[#74]: https://github.com/iqlusioninc/yubikey.rs/pull/74
+[#72]: https://github.com/iqlusioninc/yubikey.rs/pull/72
+[#71]: https://github.com/iqlusioninc/yubikey.rs/pull/71
 
 ## 0.0.1 (2019-12-02)
 - Initial release

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,7 +8,7 @@ stored on YubiKey devices.
 authors    = ["Tony Arcieri <tony@iqlusion.io>"]
 edition    = "2018"
 license    = "BSD-2-Clause"
-repository = "https://github.com/iqlusioninc/yubikey-piv.rs"
+repository = "https://github.com/iqlusioninc/yubikey.rs"
 readme     = "README.md"
 categories = ["command-line-utilities", "cryptography", "hardware-support"]
 keywords   = ["ecdsa", "rsa", "piv", "pcsc", "yubikey"]
@@ -22,4 +22,4 @@ sha2 = "0.9"
 subtle-encoding = "0.5"
 termcolor = "1"
 x509-parser = "0.9"
-yubikey-piv = { version = "0.3", path = ".." }
+yubikey = { version = "=0.4.0-pre", path = ".." }

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/iqlusioninc/yubikey-piv.rs/main/img/logo.png" width="150" height="110">
+<img src="https://raw.githubusercontent.com/iqlusioninc/yubikey.rs/main/img/logo.png" width="150" height="110">
 
 # yubikey-cli.rs
 
@@ -92,8 +92,8 @@ or conditions.
 [maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
-[build-image]: https://github.com/iqlusioninc/yubikey-piv.rs/workflows/CI/badge.svg?branch=main&event=push
-[build-link]: https://github.com/iqlusioninc/yubikey-piv.rs/actions
+[build-image]: https://github.com/iqlusioninc/yubikey.rs/workflows/CI/badge.svg?branch=main&event=push
+[build-link]: https://github.com/iqlusioninc/yubikey.rs/actions
 [gitter-image]: https://badges.gitter.im/badge.svg
 [gitter-link]: https://gitter.im/iqlusioninc/community
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -12,7 +12,7 @@ use std::{
     process::exit,
 };
 use termcolor::{ColorChoice, ColorSpec, WriteColor};
-use yubikey_piv::{Serial, YubiKey};
+use yubikey::{Serial, YubiKey};
 
 /// The `yubikey` CLI utility
 #[derive(Debug, Options)]

--- a/cli/src/commands/readers.rs
+++ b/cli/src/commands/readers.rs
@@ -7,7 +7,7 @@ use std::{
     process::exit,
 };
 use termcolor::{ColorSpec, StandardStreamLock, WriteColor};
-use yubikey_piv::{Readers, Serial};
+use yubikey::{Readers, Serial};
 
 /// The `readers` subcommand
 #[derive(Debug, Options)]

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -4,7 +4,7 @@ use crate::terminal::STDOUT;
 use gumdrop::Options;
 use std::io::{self, Write};
 use termcolor::{ColorSpec, StandardStreamLock, WriteColor};
-use yubikey_piv::{key::*, YubiKey};
+use yubikey::{key::*, YubiKey};
 
 use crate::print_cert_info;
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -20,7 +20,7 @@ use std::str;
 use subtle_encoding::hex;
 use termcolor::{ColorSpec, StandardStreamLock, WriteColor};
 use x509_parser::parse_x509_certificate;
-use yubikey_piv::{certificate::Certificate, key::*, YubiKey};
+use yubikey::{certificate::Certificate, key::*, YubiKey};
 
 ///Write information about certificate found in slot a la yubico-piv-tool output.
 pub fn print_cert_info(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@
 //!
 //! ## License
 //!
-//! **yubikey-piv.rs** is a fork of and originally a mechanical translation from
+//! **yubikey.rs** is a fork of and originally a mechanical translation from
 //! Yubico's [yubico-piv-tool], a C library/CLI program. The original library
 //! was licensed under a [2-Clause BSD License][BSDL], which this library inherits
 //! as a derived work.
@@ -83,12 +83,12 @@
 //! [YubiKey NEO]: https://support.yubico.com/support/solutions/articles/15000006494-yubikey-neo
 //! [YubiKey 4]: https://support.yubico.com/support/solutions/articles/15000006486-yubikey-4
 //! [YubiKey 5]: https://www.yubico.com/products/yubikey-5-overview/
-//! [status]: https://github.com/iqlusioninc/yubikey-piv.rs#status
+//! [status]: https://github.com/iqlusioninc/yubikey.rs#status
 //! [yubico-piv-tool]: https://github.com/Yubico/yubico-piv-tool/
 //! [Corrode]: https://github.com/jameysharp/corrode
 //! [piv-tool-guide]: https://www.yubico.com/wp-content/uploads/2016/05/Yubico_PIV_Tool_Command_Line_Guide_en.pdf
 //! [cc-web]: https://contributor-covenant.org/
-//! [cc-md]: https://github.com/iqlusioninc/yubikey-piv.rs/blob/main/CODE_OF_CONDUCT.md
+//! [cc-md]: https://github.com/iqlusioninc/yubikey.rs/blob/main/CODE_OF_CONDUCT.md
 //! [BSDL]: https://opensource.org/licenses/BSD-2-Clause
 
 // Adapted from yubico-piv-tool:
@@ -122,8 +122,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #![doc(
-    html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubikey-piv.rs/main/img/logo.png",
-    html_root_url = "https://docs.rs/yubikey-piv/0.3.0"
+    html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubikey.rs/main/img/logo.png",
+    html_root_url = "https://docs.rs/yubikey/0.4.0-pre"
 )]
 #![forbid(unsafe_code)]
 #![warn(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,7 +11,7 @@ use sha2::{Digest, Sha256};
 use std::convert::TryInto;
 use std::{env, sync::Mutex};
 use x509::RelativeDistinguishedName;
-use yubikey_piv::{
+use yubikey::{
     certificate::{Certificate, PublicKeyInfo},
     key::{self, AlgorithmId, Key, RetiredSlotId, SlotId},
     policy::{PinPolicy, TouchPolicy},


### PR DESCRIPTION
We now have publishing rights to the `yubikey` crate.

This commit renames the project to yubikey.rs