### PR TITLE
Fix `clippy::upper_case_acronyms` nits; small cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,17 +115,17 @@ Application Protocol Data Unit (APDU) messages, use the `trace` log level:
 
 ```
 running 1 test
-[INFO  yubikey_piv::yubikey] trying to connect to reader 'Yubico YubiKey OTP+FIDO+CCID'
-[INFO  yubikey_piv::yubikey] connected to 'Yubico YubiKey OTP+FIDO+CCID' successfully
-[TRACE yubikey_piv::apdu] >>> APDU { cla: 0, ins: SelectApplication, p1: 4, p2: 0, data: [160, 0, 0, 3, 8] }
-[TRACE yubikey_piv::transaction] >>> [0, 164, 4, 0, 5, 160, 0, 0, 3, 8]
-[TRACE yubikey_piv::apdu] <<< Response { status_words: Success, data: [97, 17, 79, 6, 0, 0, 16, 0, 1, 0, 121, 7, 79, 5, 160, 0, 0, 3, 8] }
-[TRACE yubikey_piv::apdu] >>> APDU { cla: 0, ins: GetVersion, p1: 0, p2: 0, data: [] }
-[TRACE yubikey_piv::transaction] >>> [0, 253, 0, 0, 0]
-[TRACE yubikey_piv::apdu] <<< Response { status_words: Success, data: [5, 1, 2] }
-[TRACE yubikey_piv::apdu] >>> APDU { cla: 0, ins: GetSerial, p1: 0, p2: 0, data: [] }
-[TRACE yubikey_piv::transaction] >>> [0, 248, 0, 0, 0]
-[TRACE yubikey_piv::apdu] <<< Response { status_words: Success, data: [0, 115, 0, 178] }
+[INFO  yubikey::yubikey] trying to connect to reader 'Yubico YubiKey OTP+FIDO+CCID'
+[INFO  yubikey::yubikey] connected to 'Yubico YubiKey OTP+FIDO+CCID' successfully
+[TRACE yubikey::apdu] >>> Apdu { cla: 0, ins: SelectApplication, p1: 4, p2: 0, data: [160, 0, 0, 3, 8] }
+[TRACE yubikey::transaction] >>> [0, 164, 4, 0, 5, 160, 0, 0, 3, 8]
+[TRACE yubikey::apdu] <<< Response { status_words: Success, data: [97, 17, 79, 6, 0, 0, 16, 0, 1, 0, 121, 7, 79, 5, 160, 0, 0, 3, 8] }
+[TRACE yubikey::apdu] >>> Apdu { cla: 0, ins: GetVersion, p1: 0, p2: 0, data: [] }
+[TRACE yubikey::transaction] >>> [0, 253, 0, 0, 0]
+[TRACE yubikey::apdu] <<< Response { status_words: Success, data: [5, 1, 2] }
+[TRACE yubikey::apdu] >>> Apdu { cla: 0, ins: GetSerial, p1: 0, p2: 0, data: [] }
+[TRACE yubikey::transaction] >>> [0, 248, 0, 0, 0]
+[TRACE yubikey::apdu] <<< Response { status_words: Success, data: [0, 115, 0, 178] }
 test connect ... ok
 ```
 

--- a/src/apdu.rs
+++ b/src/apdu.rs
@@ -41,7 +41,7 @@ const APDU_DATA_MAX: usize = 0xFF;
 ///
 /// These messages are packets used to communicate with the YubiKey.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct APDU {
+pub(crate) struct Apdu {
     /// Instruction class: indicates the type of command (e.g. inter-industry or proprietary)
     cla: u8,
 
@@ -58,7 +58,7 @@ pub(crate) struct APDU {
     data: Vec<u8>,
 }
 
-impl APDU {
+impl Apdu {
     /// Create a new APDU with the given instruction code
     pub fn new(ins: impl Into<Ins>) -> Self {
         Self {
@@ -129,13 +129,13 @@ impl APDU {
     }
 }
 
-impl Drop for APDU {
+impl Drop for Apdu {
     fn drop(&mut self) {
         self.zeroize();
     }
 }
 
-impl Zeroize for APDU {
+impl Zeroize for Apdu {
     fn zeroize(&mut self) {
         // Only `data` may contain secrets
         self.data.zeroize();

--- a/src/cccid.rs
+++ b/src/cccid.rs
@@ -77,9 +77,9 @@ impl CardId {
 
 /// Cardholder Capability Container (CCC) Identifier
 #[derive(Copy, Clone)]
-pub struct CCC(pub [u8; CCC_SIZE]);
+pub struct Ccc(pub [u8; CCC_SIZE]);
 
-impl CCC {
+impl Ccc {
     /// Return CardId component of CCC
     pub fn cccid(&self) -> Result<CardId, Error> {
         let mut cccid = [0u8; CCCID_SIZE];
@@ -101,7 +101,7 @@ impl CCC {
         Ok(Self(ccc))
     }
 
-    /// Get Cardholder Capability Container (CCC) ID
+    /// Set Cardholder Capability Container (CCC) ID
     #[cfg(feature = "untested")]
     pub fn set(&self, yubikey: &mut YubiKey) -> Result<(), Error> {
         let mut buf = CCC_TMPL.to_vec();
@@ -112,13 +112,13 @@ impl CCC {
     }
 }
 
-impl Debug for CCC {
+impl Debug for Ccc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "CCC({:?})", &self.0[..])
     }
 }
 
-impl Display for CCC {
+impl Display for Ccc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,

--- a/src/chuid.rs
+++ b/src/chuid.rs
@@ -96,9 +96,9 @@ impl Uuid {
 
 /// Cardholder Unique Identifier (CHUID)
 #[derive(Copy, Clone)]
-pub struct CHUID(pub [u8; CHUID_SIZE]);
+pub struct ChuId(pub [u8; CHUID_SIZE]);
 
-impl CHUID {
+impl ChuId {
     /// Return FASC-N component of CHUID
     pub fn fascn(&self) -> Result<[u8; FASCN_SIZE], Error> {
         let mut fascn = [0u8; FASCN_SIZE];
@@ -124,7 +124,7 @@ impl CHUID {
     }
 
     /// Get Cardholder Unique Identifier (CHUID)
-    pub fn get(yubikey: &mut YubiKey) -> Result<CHUID, Error> {
+    pub fn get(yubikey: &mut YubiKey) -> Result<ChuId, Error> {
         let txn = yubikey.begin_transaction()?;
         let response = txn.fetch_object(OBJ_CHUID)?;
 
@@ -134,13 +134,12 @@ impl CHUID {
 
         let mut chuid = [0u8; CHUID_SIZE];
         chuid.copy_from_slice(&response[0..CHUID_SIZE]);
-        let retval = CHUID { 0: chuid };
+        let retval = ChuId { 0: chuid };
         Ok(retval)
     }
 
     /// Set Cardholder Unique Identifier (CHUID)
     #[cfg(feature = "untested")]
-
     pub fn set(&self, yubikey: &mut YubiKey) -> Result<(), Error> {
         let mut buf = CHUID_TMPL.to_vec();
         buf[0..self.0.len()].copy_from_slice(&self.0);
@@ -150,7 +149,7 @@ impl CHUID {
     }
 }
 
-impl Display for CHUID {
+impl Display for ChuId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -160,7 +159,7 @@ impl Display for CHUID {
     }
 }
 
-impl Debug for CHUID {
+impl Debug for ChuId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "CHUID({:?})", &self.0[..])
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,6 @@
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubikey.rs/main/img/logo.png",
     html_root_url = "https://docs.rs/yubikey/0.4.0-pre"
 )]
-#![allow(clippy::upper_case_acronyms)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 


### PR DESCRIPTION
Renames the following to match Rust idioms:
- `APDU` => `Apdu`
- `CCC` => `Ccc`
- `CHUID` => `ChuId`

Also removes `Copy` from `mscmap::Container`, which fixes a clippy lint about its usage of `to_bytes`.