### PR TITLE
Add `Result` alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -36,7 +36,7 @@ pub struct YubiKeyCli {
 
 impl YubiKeyCli {
     /// Print usage information
-    pub fn print_usage() -> Result<(), io::Error> {
+    pub fn print_usage() -> io::Result<()> {
         let mut stdout = STDOUT.lock();
         stdout.reset()?;
 

--- a/cli/src/commands/readers.rs
+++ b/cli/src/commands/readers.rs
@@ -53,7 +53,7 @@ impl ReadersCmd {
         index: usize,
         name: &str,
         serial: Serial,
-    ) -> Result<(), io::Error> {
+    ) -> io::Result<()> {
         stream.set_color(ColorSpec::new().set_bold(true))?;
         write!(stream, "{:>3}:", index)?;
         stream.reset()?;

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -51,7 +51,7 @@ impl StatusCmd {
         stream: &mut StandardStreamLock<'_>,
         name: &str,
         value: impl ToString,
-    ) -> Result<(), io::Error> {
+    ) -> io::Result<()> {
         stream.set_color(ColorSpec::new().set_bold(true))?;
         write!(stream, "{:>12}:", name)?;
         stream.reset()?;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -27,7 +27,7 @@ pub fn print_cert_info(
     yubikey: &mut YubiKey,
     slot: SlotId,
     stream: &mut StandardStreamLock<'_>,
-) -> Result<(), io::Error> {
+) -> io::Result<()> {
     let cert = match Certificate::read(yubikey, slot) {
         Ok(c) => c,
         Err(e) => {
@@ -82,7 +82,7 @@ fn print_cert_attr(
     stream: &mut StandardStreamLock<'_>,
     name: &str,
     value: impl ToString,
-) -> Result<(), io::Error> {
+) -> io::Result<()> {
     stream.set_color(ColorSpec::new().set_bold(true))?;
     write!(stream, "{:>12}:", name)?;
     stream.reset()?;

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -143,7 +143,7 @@ impl Status {
     }
 
     /// Print the given message
-    fn print(self, stream: &StandardStream, msg: impl AsRef<str>) -> Result<(), io::Error> {
+    fn print(self, stream: &StandardStream, msg: impl AsRef<str>) -> io::Result<()> {
         let mut s = stream.lock();
         s.reset()?;
         s.set_color(ColorSpec::new().set_fg(self.color).set_bold(self.bold))?;

--- a/src/apdu.rs
+++ b/src/apdu.rs
@@ -30,7 +30,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{error::Error, transaction::Transaction, Buffer};
+use crate::{transaction::Transaction, Buffer, Result};
 use log::trace;
 use zeroize::{Zeroize, Zeroizing};
 
@@ -109,7 +109,7 @@ impl Apdu {
     }
 
     /// Transmit this APDU using the given card transaction
-    pub fn transmit(&self, txn: &Transaction<'_>, recv_len: usize) -> Result<Response, Error> {
+    pub fn transmit(&self, txn: &Transaction<'_>, recv_len: usize) -> Result<Response> {
         trace!(">>> {:?}", self);
         let response = Response::from(txn.transmit(&self.to_bytes(), recv_len)?);
         trace!("<<< {:?}", &response);

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,11 +31,10 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    error::Error,
     metadata::{AdminData, ProtectedData},
     mgm::{MgmType, ADMIN_FLAGS_1_PROTECTED_MGM},
     yubikey::{YubiKey, ADMIN_FLAGS_1_PUK_BLOCKED},
-    TAG_ADMIN_FLAGS_1, TAG_ADMIN_SALT, TAG_ADMIN_TIMESTAMP, TAG_PROTECTED_FLAGS_1,
+    Result, TAG_ADMIN_FLAGS_1, TAG_ADMIN_SALT, TAG_ADMIN_TIMESTAMP, TAG_PROTECTED_FLAGS_1,
     TAG_PROTECTED_MGM,
 };
 use log::error;
@@ -68,7 +67,7 @@ pub struct Config {
 
 impl Config {
     /// Get YubiKey config
-    pub fn get(yubikey: &mut YubiKey) -> Result<Config, Error> {
+    pub fn get(yubikey: &mut YubiKey) -> Result<Config> {
         let mut config = Config {
             protected_data_available: false,
             puk_blocked: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ mod transaction;
 pub mod yubikey;
 
 pub use self::{
-    error::Error,
+    error::{Error, Result},
     key::Key,
     mgm::MgmKey,
     readers::Readers,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -33,7 +33,7 @@
 use std::marker::PhantomData;
 use zeroize::Zeroizing;
 
-use crate::{error::Error, serialization::*, transaction::Transaction, Buffer};
+use crate::{serialization::*, transaction::Transaction, Buffer, Error, Result};
 
 #[cfg(feature = "untested")]
 use crate::{CB_OBJ_MAX, CB_OBJ_TAG_MAX};
@@ -78,7 +78,7 @@ impl<T: MetadataType> Default for Metadata<T> {
 
 impl<T: MetadataType> Metadata<T> {
     /// Read metadata
-    pub(crate) fn read(txn: &Transaction<'_>) -> Result<Self, Error> {
+    pub(crate) fn read(txn: &Transaction<'_>) -> Result<Self> {
         let data = txn.fetch_object(T::obj_id())?;
         Ok(Metadata {
             inner: Tlv::parse_single(data, T::tag())?,
@@ -88,7 +88,7 @@ impl<T: MetadataType> Metadata<T> {
 
     /// Write metadata
     #[cfg(feature = "untested")]
-    pub(crate) fn write(&self, txn: &Transaction<'_>) -> Result<(), Error> {
+    pub(crate) fn write(&self, txn: &Transaction<'_>) -> Result<()> {
         if self.inner.len() > CB_OBJ_MAX - CB_OBJ_TAG_MAX {
             return Err(Error::GenericError);
         }
@@ -105,12 +105,12 @@ impl<T: MetadataType> Metadata<T> {
 
     /// Delete metadata
     #[cfg(feature = "untested")]
-    pub(crate) fn delete(txn: &Transaction<'_>) -> Result<(), Error> {
+    pub(crate) fn delete(txn: &Transaction<'_>) -> Result<()> {
         txn.save_object(T::obj_id(), &[])
     }
 
     /// Get metadata item
-    pub(crate) fn get_item(&self, tag: u8) -> Result<&[u8], Error> {
+    pub(crate) fn get_item(&self, tag: u8) -> Result<&[u8]> {
         let mut data = &self.inner[..];
 
         while !data.is_empty() {
@@ -128,7 +128,7 @@ impl<T: MetadataType> Metadata<T> {
 
     /// Set metadata item
     #[cfg(feature = "untested")]
-    pub(crate) fn set_item(&mut self, tag: u8, item: &[u8]) -> Result<(), Error> {
+    pub(crate) fn set_item(&mut self, tag: u8, item: &[u8]) -> Result<()> {
         let mut cb_temp: usize = 0;
         let mut tag_temp: u8 = 0;
         let mut cb_len: usize = 0;

--- a/src/mscmap.rs
+++ b/src/mscmap.rs
@@ -33,7 +33,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{error::Error, key::SlotId, serialization::*, yubikey::YubiKey, CB_OBJ_MAX};
+use crate::{key::SlotId, serialization::*, Error, Result, YubiKey, CB_OBJ_MAX};
 use log::error;
 use std::convert::{TryFrom, TryInto};
 
@@ -77,7 +77,7 @@ pub struct Container {
 
 impl Container {
     /// Read MS Container Map records
-    pub fn read_mscmap(yubikey: &mut YubiKey) -> Result<Vec<Self>, Error> {
+    pub fn read_mscmap(yubikey: &mut YubiKey) -> Result<Vec<Self>> {
         let txn = yubikey.begin_transaction()?;
         let response = txn.fetch_object(OBJ_MSCMAP)?;
         let mut containers = vec![];
@@ -103,7 +103,7 @@ impl Container {
     }
 
     /// Write MS Container Map records.
-    pub fn write_mscmap(yubikey: &mut YubiKey, containers: &[Self]) -> Result<(), Error> {
+    pub fn write_mscmap(yubikey: &mut YubiKey, containers: &[Self]) -> Result<()> {
         let n_containers = containers.len();
         let data_len = n_containers * CONTAINER_REC_LEN;
 
@@ -124,7 +124,7 @@ impl Container {
     }
 
     /// Parse a container record from a byte slice
-    pub fn new(bytes: &[u8]) -> Result<Self, Error> {
+    pub fn new(bytes: &[u8]) -> Result<Self> {
         if bytes.len() != CONTAINER_REC_LEN {
             error!(
                 "couldn't parse PIV container: expected {}-bytes, got {}-bytes",
@@ -161,7 +161,7 @@ impl Container {
     }
 
     /// Parse the container name as a UTF-16 string
-    pub fn parse_name(&self) -> Result<String, Error> {
+    pub fn parse_name(&self) -> Result<String> {
         String::from_utf16(&self.name).map_err(|_| Error::ParseError)
     }
 
@@ -188,7 +188,7 @@ impl Container {
 impl<'a> TryFrom<&'a [u8]> for Container {
     type Error = Error;
 
-    fn try_from(bytes: &'a [u8]) -> Result<Self, Error> {
+    fn try_from(bytes: &'a [u8]) -> Result<Self> {
         Self::new(bytes)
     }
 }

--- a/src/msroots.rs
+++ b/src/msroots.rs
@@ -37,7 +37,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{error::Error, serialization::*, yubikey::YubiKey};
+use crate::{serialization::*, Error, Result, YubiKey};
 use crate::{CB_OBJ_MAX, CB_OBJ_TAG_MAX};
 use log::error;
 
@@ -58,12 +58,12 @@ pub struct MsRoots(Vec<u8>);
 
 impl MsRoots {
     /// Initialize a local certificate struct from the given bytebuffer
-    pub fn new(msroots: impl AsRef<[u8]>) -> Result<Self, Error> {
+    pub fn new(msroots: impl AsRef<[u8]>) -> Result<Self> {
         Ok(MsRoots(msroots.as_ref().into()))
     }
 
     /// Read `msroots` file from YubiKey
-    pub fn read(yubikey: &mut YubiKey) -> Result<Option<Self>, Error> {
+    pub fn read(yubikey: &mut YubiKey) -> Result<Option<Self>> {
         let txn = yubikey.begin_transaction()?;
 
         // allocate first page
@@ -100,7 +100,7 @@ impl MsRoots {
     }
 
     /// Write `msroots` file to YubiKey
-    pub fn write(&self, yubikey: &mut YubiKey) -> Result<(), Error> {
+    pub fn write(&self, yubikey: &mut YubiKey) -> Result<()> {
         let mut buf = [0u8; CB_OBJ_MAX];
         let mut offset: usize;
         let mut data_offset: usize = 0;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,6 +1,6 @@
 //! Enums representing key policies.
 
-use crate::{error::Error, serialization::Tlv};
+use crate::{serialization::Tlv, Result};
 
 /// Specifies how often the PIN needs to be entered for access to the credential in a
 /// given slot. This policy must be set upon key generation or importation, and cannot be
@@ -37,7 +37,7 @@ impl From<PinPolicy> for u8 {
 impl PinPolicy {
     /// Writes the `PinPolicy` in the format the YubiKey expects during key generation or
     /// importation.
-    pub(crate) fn write(self, buf: &mut [u8]) -> Result<usize, Error> {
+    pub(crate) fn write(self, buf: &mut [u8]) -> Result<usize> {
         match self {
             PinPolicy::Default => Ok(0),
             _ => Tlv::write(buf, 0xaa, &[self.into()]),
@@ -81,7 +81,7 @@ impl From<TouchPolicy> for u8 {
 impl TouchPolicy {
     /// Writes the `TouchPolicy` in the format the YubiKey expects during key generation
     /// or importation.
-    pub(crate) fn write(self, buf: &mut [u8]) -> Result<usize, Error> {
+    pub(crate) fn write(self, buf: &mut [u8]) -> Result<usize> {
         match self {
             TouchPolicy::Default => Ok(0),
             _ => Tlv::write(buf, 0xab, &[self.into()]),

--- a/src/readers.rs
+++ b/src/readers.rs
@@ -1,6 +1,6 @@
 //! Support for enumerating available readers
 
-use crate::{error::Error, yubikey::YubiKey};
+use crate::{Result, YubiKey};
 use std::{
     borrow::Cow,
     convert::TryInto,
@@ -23,7 +23,7 @@ pub struct Readers {
 impl Readers {
     /// Open a PC/SC context, which can be used to enumerate available PC/SC
     /// readers (which can be used to connect to YubiKeys).
-    pub fn open() -> Result<Self, Error> {
+    pub fn open() -> Result<Self> {
         let ctx = pcsc::Context::establish(pcsc::Scope::System)?;
         let reader_names = vec![0u8; ctx.list_readers_len()?];
         Ok(Self {
@@ -33,7 +33,7 @@ impl Readers {
     }
 
     /// Iterate over the available readers
-    pub fn iter(&mut self) -> Result<Iter<'_>, Error> {
+    pub fn iter(&mut self) -> Result<Iter<'_>> {
         let Self { ctx, reader_names } = self;
 
         let reader_cstrs: Vec<_> = {
@@ -77,12 +77,12 @@ impl<'ctx> Reader<'ctx> {
     }
 
     /// Open a connection to this reader, returning a `YubiKey` if successful
-    pub fn open(&self) -> Result<YubiKey, Error> {
+    pub fn open(&self) -> Result<YubiKey> {
         self.try_into()
     }
 
     /// Connect to this reader, returning its `pcsc::Card`
-    pub(crate) fn connect(&self) -> Result<pcsc::Card, Error> {
+    pub(crate) fn connect(&self) -> Result<pcsc::Card> {
         let ctx = self.ctx.lock().unwrap();
         Ok(ctx.connect(self.name, pcsc::ShareMode::Shared, pcsc::Protocols::T1)?)
     }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -30,7 +30,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{error::Error, Buffer, ObjectId, CB_OBJ_TAG_MIN};
+use crate::{Buffer, Error, ObjectId, Result, CB_OBJ_TAG_MIN};
 
 pub const OBJ_DISCOVERY: u32 = 0x7e;
 
@@ -44,7 +44,7 @@ pub(crate) struct Tlv<'a> {
 
 impl<'a> Tlv<'a> {
     /// Parses a `Tlv` from a buffer, returning the remainder of the buffer.
-    pub(crate) fn parse(buffer: &'a [u8]) -> Result<(&'a [u8], Self), Error> {
+    pub(crate) fn parse(buffer: &'a [u8]) -> Result<(&'a [u8], Self)> {
         if buffer.len() < CB_OBJ_TAG_MIN || !has_valid_length(&buffer[1..], buffer.len() - 1) {
             return Err(Error::SizeError);
         }
@@ -61,7 +61,7 @@ impl<'a> Tlv<'a> {
 
     /// Takes a [`Buffer`] containing a single `Tlv` with the given tag, and returns a
     /// `Buffer` containing only the value part of the `Tlv`.
-    pub(crate) fn parse_single(mut buffer: Buffer, tag: u8) -> Result<Buffer, Error> {
+    pub(crate) fn parse_single(mut buffer: Buffer, tag: u8) -> Result<Buffer> {
         if buffer.len() < CB_OBJ_TAG_MIN || !has_valid_length(&buffer[1..], buffer.len() - 1) {
             return Err(Error::SizeError);
         }
@@ -79,7 +79,7 @@ impl<'a> Tlv<'a> {
     }
 
     /// Writes a TLV to the given buffer.
-    pub(crate) fn write(buffer: &mut [u8], tag: u8, value: &[u8]) -> Result<usize, Error> {
+    pub(crate) fn write(buffer: &mut [u8], tag: u8, value: &[u8]) -> Result<usize> {
         if buffer.len() < CB_OBJ_TAG_MIN {
             return Err(Error::SizeError);
         }
@@ -103,7 +103,7 @@ impl<'a> Tlv<'a> {
         tag: u8,
         length: usize,
         value: Gen,
-    ) -> Result<usize, Error>
+    ) -> Result<usize>
     where
         Gen: FnOnce(&mut [u8]),
     {
@@ -124,7 +124,7 @@ impl<'a> Tlv<'a> {
 }
 
 /// Set length
-pub(crate) fn set_length(buffer: &mut [u8], length: usize) -> Result<usize, Error> {
+pub(crate) fn set_length(buffer: &mut [u8], length: usize) -> Result<usize> {
     if length < 0x80 {
         if buffer.is_empty() {
             Err(Error::SizeError)


### PR DESCRIPTION
Adds a `yubikey::Result` alias with `yubikey::Error` as the error type.

Since we only have one `Error` type, this simplifies the return types where a `Result` is returned.