### PR TITLE
Flatten API.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.3",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1007,7 @@ dependencies = [
  "sha2",
  "subtle",
  "subtle-encoding",
+ "uuid",
  "x509",
  "x509-parser",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ sha-1 = "0.9"
 sha2 = "0.9"
 subtle = "2"
 subtle-encoding = "0.5"
+uuid = { version = "0.8", features = ["v4"] }
 x509 = "0.2"
 x509-parser = "0.9"
 zeroize = "1"
@@ -57,3 +58,4 @@ untested = []
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -53,41 +53,6 @@ an experimental stage and may still contain high-severity issues.
 
 USE AT YOUR OWN RISK!
 
-## Status
-
-This project is a largely incomplete work-in-progress. So far the only
-functionality which has actually been tested is connecting to Yubikeys.
-
-If you're interested helping test functionality, the table below documents
-the current status of the project and relevant GitHub issues for various
-functions of the YubiKey:
-
-|    | Module        | Issue | Description |
-|----|---------------|-------|-------------|
-| 🚧 | `yubikey`     | [#20] | Core functionality: auth, keys, PIN/PUK, encrypt, sign, attest |
-| 🚧 | `cccid`       | [#21] | Cardholder Capability Container (CCC) IDs |
-| 🚧️ | `certificate` | [#22] | Certificates for stored keys |
-| 🚧 | `chuid`       | [#23] | Cardholder Unique Identifier (CHUID) |
-| ✅️ | `config`      | [#24] | Support for reading on-key configuration |
-| 🚧 | `key`         | [#26] | Crypto key management: list, generate, import |
-| 🚧 | `mgm`         | [#26] | Management Key (MGM) support: set, get, derive |
-| ⚠️ | `mscmap`      | [#25] | MS Container Map Records |
-| ⚠️ | `msroots`     | [#28] | `msroots` file: PKCS#7 formatted certificate store for enterprise trusted roots |
-
-Legend:
-
-|    | Description                        |
-|----|------------------------------------|
-| ✅ | Working                            |
-| 🚧 | Testing and validation in progress |
-| ⚠️ | Untested support                   |
-
-NOTE: Commands marked ⚠️ are disabled by default as they have have not been properly tested and may contain bugs or
-not work at all. USE AT YOUR OWN RISK!
-
-Enable the `untested` feature in your `Cargo.toml` to enable features marked ⚠️
-above.
-
 ## Testing
 
 To run the full test suite, you'll need a connected YubiKey NEO/4/5 device in

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -1,4 +1,4 @@
-//! YubiKey Certificates
+//! X.509 certificate support.
 
 // Adapted from yubico-piv-tool:
 // <https://github.com/Yubico/yubico-piv-tool/>

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,28 +46,28 @@ use std::{
 const CB_ADMIN_TIMESTAMP: usize = 0x04;
 const PROTECTED_FLAGS_1_PUK_NOBLOCK: u8 = 0x01;
 
-/// Config
+/// YubiKey configuration.
 #[derive(Copy, Clone, Debug)]
 pub struct Config {
     /// Protected data available
-    protected_data_available: bool,
+    pub protected_data_available: bool,
 
     /// PUK blocked
-    puk_blocked: bool,
+    pub puk_blocked: bool,
 
     /// No block on upgrade
-    puk_noblock_on_upgrade: bool,
+    pub puk_noblock_on_upgrade: bool,
 
     /// PIN last changed
-    pin_last_changed: Option<SystemTime>,
+    pub pin_last_changed: Option<SystemTime>,
 
     /// MGM type
-    mgm_type: MgmType,
+    pub mgm_type: MgmType,
 }
 
 impl Config {
-    /// Get YubiKey config
-    pub fn get(yubikey: &mut YubiKey) -> Result<Config> {
+    /// Get YubiKey config.
+    pub(crate) fn get(yubikey: &mut YubiKey) -> Result<Config> {
         let mut config = Config {
             protected_data_available: false,
             puk_blocked: false,
@@ -129,9 +129,7 @@ impl Config {
 
             if protected_data.get_item(TAG_PROTECTED_MGM).is_ok() {
                 if config.mgm_type != MgmType::Protected {
-                    error!(
-                        "conflicting types of mgm key administration configured: protected MGM exists"
-                    );
+                    error!("conflicting MGM key types: protected MGM exists");
                 }
 
                 // Always favor protected MGM

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ use std::fmt::{self, Display};
 /// Result type with [`Error`].
 pub type Result<T> = core::result::Result<T, Error>;
 
-/// Kinds of errors
+/// Kinds of errors.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Error {

--- a/src/key.rs
+++ b/src/key.rs
@@ -350,10 +350,13 @@ pub const SLOTS: [SlotId; 24] = [
 pub enum AlgorithmId {
     /// 1024-bit RSA.
     Rsa1024,
+
     /// 2048-bit RSA.
     Rsa2048,
+
     /// ECDSA with the NIST P256 curve.
     EccP256,
+
     /// ECDSA with the NIST P384 curve.
     EccP384,
 }
@@ -390,6 +393,7 @@ impl AlgorithmId {
     }
 
     #[cfg(feature = "untested")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
     fn get_elem_len(self) -> usize {
         match self {
             AlgorithmId::Rsa1024 => 64,
@@ -400,6 +404,7 @@ impl AlgorithmId {
     }
 
     #[cfg(feature = "untested")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
     fn get_param_tag(self) -> u8 {
         match self {
             AlgorithmId::Rsa1024 | AlgorithmId::Rsa2048 => 0x01,
@@ -453,8 +458,7 @@ impl Key {
     }
 }
 
-/// Generate key
-#[allow(clippy::cognitive_complexity)]
+/// Generate new key.
 pub fn generate(
     yubikey: &mut YubiKey,
     slot: SlotId,
@@ -473,7 +477,7 @@ pub fn generate(
     const SZ_ROCA_BLOCK_ADMIN: &str = "was blocked due to an administrator configuration setting.";
     const SZ_ROCA_DEFAULT: &str = "was permitted by default, but is not recommended.  The default behavior will change in a future Yubico release.";
 
-    let setting_roca: settings::ConfigValue;
+    let setting_roca: settings::SettingValue;
 
     match algorithm {
         AlgorithmId::Rsa1024 | AlgorithmId::Rsa2048 => {
@@ -481,17 +485,17 @@ pub fn generate(
                 && (yubikey.version.minor < 3
                     || yubikey.version.minor == 3 && (yubikey.version.patch < 5))
             {
-                setting_roca = settings::ConfigValue::get(SZ_SETTING_ROCA, true);
+                setting_roca = settings::SettingValue::get(SZ_SETTING_ROCA, true);
 
                 let psz_msg = match setting_roca.source {
-                    settings::Source::User => {
+                    settings::SettingSource::User => {
                         if setting_roca.value {
                             SZ_ROCA_ALLOW_USER
                         } else {
                             SZ_ROCA_BLOCK_USER
                         }
                     }
-                    settings::Source::Admin => {
+                    settings::SettingSource::Admin => {
                         if setting_roca.value {
                             SZ_ROCA_ALLOW_ADMIN
                         } else {
@@ -660,6 +664,7 @@ pub fn generate(
 }
 
 #[cfg(feature = "untested")]
+#[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
 fn write_key(
     yubikey: &mut YubiKey,
     slot: SlotId,
@@ -708,6 +713,7 @@ fn write_key(
 
 /// The key data that makes up an RSA key.
 #[cfg(feature = "untested")]
+#[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
 pub struct RsaKeyData {
     /// The secret prime `p`.
     p: Buffer,
@@ -769,6 +775,7 @@ impl RsaKeyData {
 ///
 /// Errors if `algorithm` isn't `AlgorithmId::Rsa1024` or `AlgorithmId::Rsa2048`.
 #[cfg(feature = "untested")]
+#[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
 pub fn import_rsa_key(
     yubikey: &mut YubiKey,
     slot: SlotId,
@@ -803,6 +810,7 @@ pub fn import_rsa_key(
 ///
 /// Errors if `algorithm` isn't `AlgorithmId::EccP256` or ` AlgorithmId::EccP384`.
 #[cfg(feature = "untested")]
+#[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
 pub fn import_ecc_key(
     yubikey: &mut YubiKey,
     slot: SlotId,
@@ -828,8 +836,10 @@ pub fn import_ecc_key(
 }
 
 /// Generate an attestation certificate for a stored key.
+///
 /// <https://developers.yubico.com/PIV/Introduction/PIV_attestation.html>
 #[cfg(feature = "untested")]
+#[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
 pub fn attest(yubikey: &mut YubiKey, key: SlotId) -> Result<Buffer> {
     let templ = [0, Ins::Attest.code(), key.into(), 0];
     let txn = yubikey.begin_transaction()?;
@@ -850,7 +860,7 @@ pub fn attest(yubikey: &mut YubiKey, key: SlotId) -> Result<Buffer> {
     Ok(Buffer::new(response.data().into()))
 }
 
-/// Sign data using a PIV key
+/// Sign data using a PIV key.
 pub fn sign_data(
     yubikey: &mut YubiKey,
     raw_in: &[u8],
@@ -863,8 +873,9 @@ pub fn sign_data(
     txn.authenticated_command(raw_in, algorithm, key, false)
 }
 
-/// Decrypt data using a PIV key
+/// Decrypt data using a PIV key.
 #[cfg(feature = "untested")]
+#[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
 pub fn decrypt_data(
     yubikey: &mut YubiKey,
     input: &[u8],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,14 +34,6 @@
 //!
 //! NOTE: RSASSA-PSS signatures and RSA-OAEP encryption may be supportable (TBD)
 //!
-//! ## Status
-//!
-//! This is a work-in-progress effort, and while much of the library-level
-//! code from upstream [yubico-piv-tool] has been translated into Rust
-//! presenting a safe interface, much of it is still untested.
-//!
-//! Please see the [project's README.md for a complete status][status].
-//!
 //! ## History
 //!
 //! This library is a Rust translation of the [yubico-piv-tool] utility by
@@ -83,7 +75,6 @@
 //! [YubiKey NEO]: https://support.yubico.com/support/solutions/articles/15000006494-yubikey-neo
 //! [YubiKey 4]: https://support.yubico.com/support/solutions/articles/15000006486-yubikey-4
 //! [YubiKey 5]: https://www.yubico.com/products/yubikey-5-overview/
-//! [status]: https://github.com/iqlusioninc/yubikey.rs#status
 //! [yubico-piv-tool]: https://github.com/Yubico/yubico-piv-tool/
 //! [Corrode]: https://github.com/jameysharp/corrode
 //! [piv-tool-guide]: https://www.yubico.com/wp-content/uploads/2016/05/Yubico_PIV_Tool_Command_Line_Guide_en.pdf
@@ -121,6 +112,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubikey.rs/main/img/logo.png",
     html_root_url = "https://docs.rs/yubikey/0.4.0-pre"
@@ -129,34 +121,44 @@
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
 mod apdu;
-pub mod cccid;
+mod cccid;
 pub mod certificate;
-pub mod chuid;
-pub mod config;
-pub mod error;
+mod chuid;
+mod config;
+mod error;
 pub mod key;
 mod metadata;
-pub mod mgm;
+mod mgm;
 #[cfg(feature = "untested")]
-pub mod mscmap;
+mod mscmap;
 #[cfg(feature = "untested")]
-pub mod msroots;
-pub mod policy;
+mod msroots;
+mod policy;
 pub mod readers;
 mod serialization;
-pub mod settings;
+mod settings;
 mod transaction;
-pub mod yubikey;
+mod yubikey;
 
-pub use self::{
+pub use crate::{
+    cccid::{CardId, Ccc},
+    chuid::ChuId,
+    config::Config,
     error::{Error, Result},
     key::Key,
-    mgm::MgmKey,
+    mgm::{MgmKey, MgmType},
+    policy::{PinPolicy, TouchPolicy},
     readers::Readers,
-    yubikey::{Serial, YubiKey},
+    settings::{SettingSource, SettingValue},
+    yubikey::{CachedPin, Serial, Version, YubiKey},
 };
 
-/// Object identifiers
+#[cfg(feature = "untested")]
+pub use crate::{mscmap::MsContainer, msroots::MsRoots};
+
+pub use uuid::Uuid;
+
+/// Object identifiers: handles to particular objects stored on a YubiKey.
 pub type ObjectId = u32;
 
 /// Buffer type (self-zeroizing byte vector)

--- a/src/mgm.rs
+++ b/src/mgm.rs
@@ -73,7 +73,7 @@ pub(crate) const DES_LEN_3DES: usize = DES_LEN_DES * 3;
 #[cfg(feature = "untested")]
 const ITER_MGM_PBKDF2: u32 = 10000;
 
-/// Management Key (MGM) key types (manual/derived/protected)
+/// Management Key (MGM) key types (manual/derived/protected).
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum MgmType {
     /// Manual
@@ -132,6 +132,7 @@ impl MgmKey {
 
     /// Get derived management key (MGM)
     #[cfg(feature = "untested")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
     pub fn get_derived(yubikey: &mut YubiKey, pin: &[u8]) -> Result<Self> {
         let txn = yubikey.begin_transaction()?;
 
@@ -157,6 +158,7 @@ impl MgmKey {
 
     /// Get protected management key (MGM)
     #[cfg(feature = "untested")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
     pub fn get_protected(yubikey: &mut YubiKey) -> Result<Self> {
         let txn = yubikey.begin_transaction()?;
 
@@ -187,6 +189,7 @@ impl MgmKey {
     ///
     /// This will wipe any metadata related to derived and PIN-protected management keys.
     #[cfg(feature = "untested")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
     pub fn set_default(yubikey: &mut YubiKey) -> Result<()> {
         MgmKey::default().set_manual(yubikey, false)
     }
@@ -198,6 +201,7 @@ impl MgmKey {
     ///
     /// This will wipe any metadata related to derived and PIN-protected management keys.
     #[cfg(feature = "untested")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
     pub fn set_manual(&self, yubikey: &mut YubiKey, require_touch: bool) -> Result<()> {
         let txn = yubikey.begin_transaction()?;
 
@@ -257,6 +261,7 @@ impl MgmKey {
     ///
     /// This enables key management operations to be performed with access to the PIN.
     #[cfg(feature = "untested")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
     pub fn set_protected(&self, yubikey: &mut YubiKey) -> Result<()> {
         let txn = yubikey.begin_transaction()?;
 

--- a/src/mscmap.rs
+++ b/src/mscmap.rs
@@ -1,7 +1,4 @@
-//! MS Container Map Records
-//!
-//! These appear(?) to be defined in Microsoft's Smart Card Minidriver Specification:
-//! <https://docs.microsoft.com/en-us/previous-versions/windows/hardware/design/dn631754(v=vs.85)>
+//! MS Container Map Records.
 
 // Adapted from yubico-piv-tool:
 // <https://github.com/Yubico/yubico-piv-tool/>
@@ -37,46 +34,53 @@ use crate::{key::SlotId, serialization::*, Error, Result, YubiKey, CB_OBJ_MAX};
 use log::error;
 use std::convert::{TryFrom, TryInto};
 
-/// Container name length
-const CONTAINER_NAME_LEN: usize = 40;
-
-/// Container record length: 27 = 80 + 1 + 1 + 2 + 1 + 1 + 1 + 20
-const CONTAINER_REC_LEN: usize = (2 * CONTAINER_NAME_LEN) + 27;
-
 const OBJ_MSCMAP: u32 = 0x005f_ff10;
 
 const TAG_MSCMAP: u8 = 0x81;
 
-/// MS Container Map(?) Records
+/// MS Container Map records.
+///
+/// Defined in Microsoft's Smart Card Minidriver Specification:
+/// <https://docs.microsoft.com/en-us/previous-versions/windows/hardware/design/dn631754(v=vs.85)>
+#[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
 #[derive(Clone, Debug)]
-pub struct Container {
-    /// Container name
-    pub name: [u16; CONTAINER_NAME_LEN],
+pub struct MsContainer {
+    /// Container name.
+    pub name: [u16; Self::NAME_LEN],
 
-    /// Card slot
+    /// Card slot.
     pub slot: SlotId,
 
-    /// Key spec
+    /// Key spec.
     pub key_spec: u8,
 
-    /// Key size in bits
+    /// Key size in bits.
     pub key_size_bits: u16,
 
-    /// Flags
+    /// Flags.
     pub flags: u8,
 
-    /// PIN ID
+    /// PIN ID.
     pub pin_id: u8,
 
-    /// Associated ECHD(?) container (typo of "ecdh" perhaps?)
+    /// Associated ECHD container.
     pub associated_echd_container: u8,
 
-    /// Cert fingerprint
-    pub cert_fingerprint: [u8; 20],
+    /// Cert fingerprint.
+    pub cert_fingerprint: [u8; Self::CERT_FINGERPRINT_LEN],
 }
 
-impl Container {
-    /// Read MS Container Map records
+impl MsContainer {
+    /// Container name length in UTF-16 chars.
+    const NAME_LEN: usize = 40;
+
+    /// Container record length: 27 = 80 + 1 + 1 + 2 + 1 + 1 + 1 + 20
+    const REC_LEN: usize = (2 * Self::NAME_LEN) + 27;
+
+    /// Length of a certificate fingerprint.
+    const CERT_FINGERPRINT_LEN: usize = 20;
+
+    /// Read MS Container Map records.
     pub fn read_mscmap(yubikey: &mut YubiKey) -> Result<Vec<Self>> {
         let txn = yubikey.begin_transaction()?;
         let response = txn.fetch_object(OBJ_MSCMAP)?;
@@ -95,8 +99,8 @@ impl Container {
             return Err(Error::InvalidObject);
         }
 
-        for chunk in tlv.value.chunks_exact(CONTAINER_REC_LEN) {
-            containers.push(Container::new(chunk)?);
+        for chunk in tlv.value.chunks_exact(Self::REC_LEN) {
+            containers.push(MsContainer::new(chunk)?);
         }
 
         Ok(containers)
@@ -105,7 +109,7 @@ impl Container {
     /// Write MS Container Map records.
     pub fn write_mscmap(yubikey: &mut YubiKey, containers: &[Self]) -> Result<()> {
         let n_containers = containers.len();
-        let data_len = n_containers * CONTAINER_REC_LEN;
+        let data_len = n_containers * Self::REC_LEN;
 
         let txn = yubikey.begin_transaction()?;
 
@@ -115,7 +119,7 @@ impl Container {
 
         let mut buf = [0u8; CB_OBJ_MAX];
         let offset = Tlv::write_as(&mut buf, TAG_MSCMAP, data_len, |buf| {
-            for (i, chunk) in buf.chunks_exact_mut(CONTAINER_REC_LEN).enumerate() {
+            for (i, chunk) in buf.chunks_exact_mut(Self::REC_LEN).enumerate() {
                 chunk.copy_from_slice(&containers[i].to_bytes());
             }
         })?;
@@ -123,19 +127,19 @@ impl Container {
         txn.save_object(OBJ_MSCMAP, &buf[..offset])
     }
 
-    /// Parse a container record from a byte slice
+    /// Parse a container record from a byte slice.
     pub fn new(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() != CONTAINER_REC_LEN {
+        if bytes.len() != Self::REC_LEN {
             error!(
                 "couldn't parse PIV container: expected {}-bytes, got {}-bytes",
-                CONTAINER_REC_LEN,
+                Self::REC_LEN,
                 bytes.len()
             );
             return Err(Error::ParseError);
         }
 
-        let mut name = [0u16; CONTAINER_NAME_LEN];
-        let name_bytes_len = CONTAINER_NAME_LEN * 2;
+        let mut name = [0u16; Self::NAME_LEN];
+        let name_bytes_len = Self::NAME_LEN * 2;
 
         for (i, chunk) in bytes[..name_bytes_len].chunks_exact(2).enumerate() {
             name[i] = u16::from_le_bytes(chunk.try_into().unwrap());
@@ -144,7 +148,7 @@ impl Container {
         let mut cert_fingerprint = [0u8; 20];
         cert_fingerprint.copy_from_slice(&bytes[(bytes.len() - 20)..]);
 
-        Ok(Container {
+        Ok(Self {
             name,
             slot: bytes[name_bytes_len].try_into()?,
             key_spec: bytes[name_bytes_len + 1],
@@ -160,17 +164,17 @@ impl Container {
         })
     }
 
-    /// Parse the container name as a UTF-16 string
+    /// Parse the container name as a UTF-16 string.
     pub fn parse_name(&self) -> Result<String> {
         String::from_utf16(&self.name).map_err(|_| Error::ParseError)
     }
 
-    /// Serialize a container record as a byte size
-    pub fn to_bytes(&self) -> [u8; CONTAINER_REC_LEN] {
+    /// Serialize a container record as a byte size.
+    pub fn to_bytes(&self) -> [u8; Self::REC_LEN] {
         // TODO(tarcieri): use array instead of `Vec`
-        let mut bytes = Vec::with_capacity(CONTAINER_REC_LEN);
+        let mut bytes = Vec::with_capacity(Self::REC_LEN);
 
-        for i in 0..CONTAINER_NAME_LEN {
+        for i in 0..Self::NAME_LEN {
             bytes.extend_from_slice(&self.name[i].to_le_bytes());
         }
 
@@ -185,7 +189,7 @@ impl Container {
     }
 }
 
-impl<'a> TryFrom<&'a [u8]> for Container {
+impl<'a> TryFrom<&'a [u8]> for MsContainer {
     type Error = Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {

--- a/src/msroots.rs
+++ b/src/msroots.rs
@@ -1,11 +1,4 @@
-//! `msroots`: PKCS#7 formatted certificate store for enterprise trusted roots.
-//!
-//! This `msroots` file contains a bag of certificates with empty content and
-//! an empty signature, allowing an enterprise root certificate truststore to
-//! be written to and read from a YubiKey.
-//!
-//! For more information, see:
-//! <https://docs.microsoft.com/en-us/windows-hardware/drivers/smartcard/developer-guidelines#-interoperability-with-msroots>
+//! PKCS#7 formatted certificate store for enterprise trusted roots.
 
 // Adapted from yubico-piv-tool:
 // <https://github.com/Yubico/yubico-piv-tool/>
@@ -53,7 +46,15 @@ const OBJ_MSROOTS5: u32 = 0x005f_ff15;
 const TAG_MSROOTS_END: u8 = 0x82;
 const TAG_MSROOTS_MID: u8 = 0x83;
 
-/// `msroots` file: PKCS#7-formatted certificate store for enterprise trust roots
+/// PKCS#7-formatted certificate store for enterprise trust roots.
+///
+/// The `msroots` file contains a bag of certificates with empty content and
+/// an empty signature, allowing an enterprise root certificate truststore to
+/// be written to and read from a YubiKey.
+///
+/// For more information, see:
+/// <https://docs.microsoft.com/en-us/windows-hardware/drivers/smartcard/developer-guidelines#-interoperability-with-msroots>
+#[cfg_attr(docsrs, doc(cfg(feature = "untested")))]
 pub struct MsRoots(Vec<u8>);
 
 impl MsRoots {

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -3,8 +3,9 @@
 use crate::{serialization::Tlv, Result};
 
 /// Specifies how often the PIN needs to be entered for access to the credential in a
-/// given slot. This policy must be set upon key generation or importation, and cannot be
-/// changed later.
+/// given slot.
+///
+/// This policy must be set when keys are generated or imported, and cannot be changed later.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PinPolicy {
     /// Use the default PIN policy for the slot. See the slot's documentation for details.
@@ -46,8 +47,9 @@ impl PinPolicy {
 }
 
 /// Specifies under what conditions a physical touch on the metal contact is required, in
-/// addition to the [`PinPolicy`]. This policy must be set upon key generation or
-/// importation, and cannot be changed later.
+/// addition to the [`PinPolicy`].
+///
+/// This policy must be set when keys are generated or imported, and cannot be changed later.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TouchPolicy {
     /// Use the default touch policy for the slot.

--- a/src/readers.rs
+++ b/src/readers.rs
@@ -1,4 +1,4 @@
-//! Support for enumerating available readers
+//! Support for enumerating available PC/SC card readers.
 
 use crate::{Result, YubiKey};
 use std::{
@@ -32,7 +32,7 @@ impl Readers {
         })
     }
 
-    /// Iterate over the available readers
+    /// Iterate over the available readers.
     pub fn iter(&mut self) -> Result<Iter<'_>> {
         let Self { ctx, reader_names } = self;
 
@@ -54,7 +54,7 @@ impl Readers {
     }
 }
 
-/// An individual connected reader
+/// An individual connected PC/SC card reader.
 pub struct Reader<'ctx> {
     /// Name of this reader
     name: &'ctx CStr,
@@ -64,24 +64,24 @@ pub struct Reader<'ctx> {
 }
 
 impl<'ctx> Reader<'ctx> {
-    /// Create a new reader from its name and context
+    /// Create a new reader from its name and context.
     fn new(name: &'ctx CStr, ctx: Arc<Mutex<pcsc::Context>>) -> Self {
         // TODO(tarcieri): open devices, determine they're YubiKeys, get serial?
         Self { name, ctx }
     }
 
-    /// Get this reader's name
+    /// Get this reader's name.
     pub fn name(&self) -> Cow<'_, str> {
         // TODO(tarcieri): is lossy ok here? try to avoid lossiness?
         self.name.to_string_lossy()
     }
 
-    /// Open a connection to this reader, returning a `YubiKey` if successful
+    /// Open a connection to this reader, returning a `YubiKey` if successful.
     pub fn open(&self) -> Result<YubiKey> {
         self.try_into()
     }
 
-    /// Connect to this reader, returning its `pcsc::Card`
+    /// Connect to this reader, returning its `pcsc::Card`.
     pub(crate) fn connect(&self) -> Result<pcsc::Card> {
         let ctx = self.ctx.lock().unwrap();
         Ok(ctx.connect(self.name, pcsc::ShareMode::Shared, pcsc::Protocols::T1)?)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17,8 +17,7 @@ use x509::RelativeDistinguishedName;
 use yubikey::{
     certificate::{Certificate, PublicKeyInfo},
     key::{self, AlgorithmId, Key, RetiredSlotId, SlotId},
-    policy::{PinPolicy, TouchPolicy},
-    Error, MgmKey, YubiKey,
+    Error, MgmKey, PinPolicy, TouchPolicy, YubiKey,
 };
 
 lazy_static! {


### PR DESCRIPTION
Re-exports types from the toplevel instead of placing them in individual modules (often which only contain one type).

This makes the API easier for users to navigate, while still retaining the same module structure internally.

Additionally, this commit uses the `uuid` crate for modeling UUIDs.