### PR TITLE
Replace `getrandom` with `rand_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,24 +279,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -632,7 +621,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -893,7 +882,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -901,12 +890,6 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -989,7 +972,6 @@ dependencies = [
  "des",
  "elliptic-curve",
  "env_logger",
- "getrandom 0.1.16",
  "hmac",
  "lazy_static",
  "log",
@@ -1001,6 +983,7 @@ dependencies = [
  "p384",
  "pbkdf2",
  "pcsc",
+ "rand_core",
  "rsa",
  "secrecy",
  "sha-1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,17 +27,17 @@ cookie-factory = "0.3"
 der-parser = "5"
 des = "0.7"
 elliptic-curve = "0.10"
-getrandom = "0.1"
 hmac = "0.11"
 log = "0.4"
 nom = "6"
-num-bigint-dig = { version = "0.7", features = ["rand"], package = "num-bigint-dig" }
+num-bigint-dig = { version = "0.7", features = ["rand"] }
 num-traits = "0.2"
 num-integer = "0.1"
 pbkdf2 = { version = "0.8", default-features = false }
 p256 = "0.9"
 p384 = "0.8"
 pcsc = "2"
+rand_core = { version = "0.6", features = ["std"] }
 rsa = "0.4"
 secrecy = "0.7"
 sha-1 = "0.9"

--- a/src/cccid.rs
+++ b/src/cccid.rs
@@ -31,7 +31,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{Error, Result, YubiKey};
-use getrandom::getrandom;
+use rand_core::{OsRng, RngCore};
 use std::{
     fmt::{self, Debug, Display},
     str,
@@ -68,10 +68,10 @@ impl CardId {
     pub const BYTE_SIZE: usize = 14;
 
     /// Generate a random CCC Card ID
-    pub fn generate() -> Result<Self> {
+    pub fn generate() -> Self {
         let mut id = [0u8; Self::BYTE_SIZE];
-        getrandom(&mut id).map_err(|_| Error::RandomnessError)?;
-        Ok(Self(id))
+        OsRng.fill_bytes(&mut id);
+        Self(id)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,17 +65,22 @@ pub struct Config {
     pub mgm_type: MgmType,
 }
 
-impl Config {
-    /// Get YubiKey config.
-    pub(crate) fn get(yubikey: &mut YubiKey) -> Result<Config> {
-        let mut config = Config {
+impl Default for Config {
+    fn default() -> Config {
+        Config {
             protected_data_available: false,
             puk_blocked: false,
             puk_noblock_on_upgrade: false,
             pin_last_changed: None,
             mgm_type: MgmType::Manual,
-        };
+        }
+    }
+}
 
+impl Config {
+    /// Get YubiKey config.
+    pub(crate) fn get(yubikey: &mut YubiKey) -> Result<Config> {
+        let mut config = Self::default();
         let txn = yubikey.begin_transaction()?;
 
         if let Ok(admin_data) = AdminData::read(&txn) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,9 +81,6 @@ pub enum Error {
     /// PIN locked
     PinLocked,
 
-    /// Randomness error
-    RandomnessError,
-
     /// Range error
     RangeError,
 
@@ -116,7 +113,6 @@ impl Error {
             Error::ParseError => "YKPIV_PARSE_ERROR",
             Error::PcscError { .. } => "YKPIV_PCSC_ERROR",
             Error::PinLocked => "YKPIV_PIN_LOCKED",
-            Error::RandomnessError => "YKPIV_RANDOMNESS_ERROR",
             Error::RangeError => "YKPIV_RANGE_ERROR",
             Error::SizeError => "YKPIV_SIZE_ERROR",
             Error::WrongPin { .. } => "YKPIV_WRONG_PIN",
@@ -140,7 +136,6 @@ impl Error {
             Error::ParseError => "parse error",
             Error::PcscError { .. } => "PC/SC error",
             Error::PinLocked => "PIN locked",
-            Error::RandomnessError => "randomness error",
             Error::RangeError => "range error",
             Error::SizeError => "size error",
             Error::WrongPin { .. } => "wrong pin",

--- a/src/key.rs
+++ b/src/key.rs
@@ -47,20 +47,19 @@ use crate::{
     yubikey::YubiKey,
     Buffer, ObjectId,
 };
-use log::debug;
+use elliptic_curve::sec1::EncodedPoint as EcPublicKey;
+use log::{debug, error, warn};
+use rsa::{BigUint, RSAPublicKey};
 use std::convert::TryFrom;
 
 #[cfg(feature = "untested")]
-use crate::CB_OBJ_MAX;
-use elliptic_curve::sec1::EncodedPoint as EcPublicKey;
-use log::{error, warn};
-#[cfg(feature = "untested")]
-use num_bigint_dig::traits::ModInverse;
-#[cfg(feature = "untested")]
-use num_integer::Integer;
-#[cfg(feature = "untested")]
-use num_traits::{FromPrimitive, One};
-use rsa::{BigUint, RSAPublicKey};
+use {
+    crate::CB_OBJ_MAX,
+    num_bigint_dig::traits::ModInverse,
+    num_integer::Integer,
+    num_traits::{FromPrimitive, One},
+};
+
 #[cfg(feature = "untested")]
 use zeroize::Zeroizing;
 


### PR DESCRIPTION
`rand_core::OsRng` provides a facade over `getrandom` which simplifies error handling.