### PR TITLE
Rename `readers` module to `reader`; `Readers` => `Context`

### DIFF
--- a/cli/src/commands/readers.rs
+++ b/cli/src/commands/readers.rs
@@ -7,7 +7,7 @@ use std::{
     process::exit,
 };
 use termcolor::{ColorSpec, StandardStreamLock, WriteColor};
-use yubikey::{Readers, Serial};
+use yubikey::{Context, Serial};
 
 /// The `readers` subcommand
 #[derive(Debug, Options)]
@@ -16,7 +16,7 @@ pub struct ReadersCmd {}
 impl ReadersCmd {
     /// Run the `readers` subcommand
     pub fn run(&self) {
-        let mut readers = Readers::open().unwrap_or_else(|e| {
+        let mut readers = Context::open().unwrap_or_else(|e| {
             status_err!("couldn't open PC/SC context: {}", e);
             exit(1);
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,15 @@
 //!
 //! NOTE: RSASSA-PSS signatures and RSA-OAEP encryption may be supportable (TBD)
 //!
+//! # Status
+//!
+//! Functionality which has been successfully tested is available by default.
+//!
+//! Any functionality which is gated on the `untested` feature has not been
+//! properly tested and is not known to function correctly.
+//!
+//! If
+//!
 //! # History
 //!
 //! This library is a Rust translation of the [yubico-piv-tool] utility by
@@ -141,7 +150,7 @@ mod mscmap;
 mod msroots;
 pub mod piv;
 mod policy;
-pub mod readers;
+pub mod reader;
 mod serialization;
 mod settings;
 mod transaction;
@@ -155,7 +164,7 @@ pub use crate::{
     mgm::{MgmKey, MgmType},
     piv::Key,
     policy::{PinPolicy, TouchPolicy},
-    readers::Readers,
+    reader::Context,
     settings::{SettingSource, SettingValue},
     yubikey::{CachedPin, Serial, Version, YubiKey},
 };

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -11,8 +11,8 @@ use std::{
 /// Iterator over connected readers
 pub type Iter<'ctx> = std::vec::IntoIter<Reader<'ctx>>;
 
-/// Enumeration support for available readers
-pub struct Readers {
+/// PC/SC reader context: used to enumerate available PC/SC [`Reader`]s.
+pub struct Context {
     /// PC/SC context
     ctx: Arc<Mutex<pcsc::Context>>,
 
@@ -20,7 +20,7 @@ pub struct Readers {
     reader_names: Vec<u8>,
 }
 
-impl Readers {
+impl Context {
     /// Open a PC/SC context, which can be used to enumerate available PC/SC
     /// readers (which can be used to connect to YubiKeys).
     pub fn open() -> Result<Self> {

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -38,7 +38,7 @@ use crate::{
     error::{Error, Result},
     mgm::MgmKey,
     piv,
-    readers::{Reader, Readers},
+    reader::{Context, Reader},
     transaction::Transaction,
 };
 use log::{error, info};
@@ -155,10 +155,10 @@ impl YubiKey {
     ///
     /// If you need to operate in environments with more than one YubiKey
     /// attached to the same system, use [`YubiKey::open_by_serial`] or
-    /// [`yubikey::Readers`][`Readers`] to select from the available
+    /// [`yubikey::reader::Context`][`Context`] to select from the available
     /// PC/SC readers.
     pub fn open() -> Result<Self> {
-        let mut readers = Readers::open().map_err(|e| match e {
+        let mut readers = Context::open().map_err(|e| match e {
             Error::PcscError {
                 inner: Some(pcsc::Error::NoReadersAvailable),
             } => Error::NotFound,
@@ -181,7 +181,7 @@ impl YubiKey {
 
     /// Open a YubiKey with a specific serial number.
     pub fn open_by_serial(serial: Serial) -> Result<Self> {
-        let mut readers = Readers::open().map_err(|e| match e {
+        let mut readers = Context::open().map_err(|e| match e {
             Error::PcscError {
                 inner: Some(pcsc::Error::NoReadersAvailable),
             } => Error::NotFound,


### PR DESCRIPTION
Renames the `readers` module to be singular: `reader`.

Renames the former `readers::Readers` struct to `reader::Context`.