### PR TITLE
Extract `consts` module

### DIFF
--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -31,6 +31,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    consts::CB_OBJ_MAX,
     error::{Error, Result},
     piv::{sign_data, AlgorithmId, SlotId},
     serialization::*,
@@ -52,8 +53,6 @@ use std::ops::DerefMut;
 use x509::{der::Oid, RelativeDistinguishedName};
 use x509_parser::{parse_x509_certificate, x509::SubjectPublicKeyInfo};
 use zeroize::Zeroizing;
-
-use crate::CB_OBJ_MAX;
 
 // TODO: Make these der_parser::oid::Oid constants when it has const fn support.
 const OID_RSA_ENCRYPTION: &str = "1.2.840.113549.1.1.1";

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,11 +31,14 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    consts::{
+        TAG_ADMIN_FLAGS_1, TAG_ADMIN_SALT, TAG_ADMIN_TIMESTAMP, TAG_PROTECTED_FLAGS_1,
+        TAG_PROTECTED_MGM,
+    },
     metadata::{AdminData, ProtectedData},
     mgm::{MgmType, ADMIN_FLAGS_1_PROTECTED_MGM},
     yubikey::{YubiKey, ADMIN_FLAGS_1_PUK_BLOCKED},
-    Result, TAG_ADMIN_FLAGS_1, TAG_ADMIN_SALT, TAG_ADMIN_TIMESTAMP, TAG_PROTECTED_FLAGS_1,
-    TAG_PROTECTED_MGM,
+    Result,
 };
 use log::error;
 use std::{

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,0 +1,20 @@
+//! Miscellaneous constant values
+
+/// YubiKey max buffer size
+pub(crate) const CB_BUF_MAX: usize = 3072;
+
+/// YubiKey max object size
+pub(crate) const CB_OBJ_MAX: usize = CB_BUF_MAX - 9;
+
+pub(crate) const CB_OBJ_TAG_MIN: usize = 2; // 1 byte tag + 1 byte len
+#[cfg(feature = "untested")]
+pub(crate) const CB_OBJ_TAG_MAX: usize = CB_OBJ_TAG_MIN + 2; // 1 byte tag + 3 bytes len
+
+// Admin tags
+pub(crate) const TAG_ADMIN_FLAGS_1: u8 = 0x81;
+pub(crate) const TAG_ADMIN_SALT: u8 = 0x82;
+pub(crate) const TAG_ADMIN_TIMESTAMP: u8 = 0x83;
+
+// Protected tags
+pub(crate) const TAG_PROTECTED_FLAGS_1: u8 = 0x81;
+pub(crate) const TAG_PROTECTED_MGM: u8 = 0x89;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,7 @@ mod cccid;
 pub mod certificate;
 mod chuid;
 mod config;
+mod consts;
 mod error;
 mod metadata;
 mod mgm;
@@ -179,30 +180,3 @@ pub type ObjectId = u32;
 
 /// Buffer type (self-zeroizing byte vector)
 pub(crate) type Buffer = zeroize::Zeroizing<Vec<u8>>;
-
-/// YubiKey max buffer size
-pub(crate) const CB_BUF_MAX: usize = 3072;
-
-/// YubiKey max object size
-pub(crate) const CB_OBJ_MAX: usize = CB_BUF_MAX - 9;
-pub(crate) const CB_OBJ_TAG_MIN: usize = 2; // 1 byte tag + 1 byte len
-#[cfg(feature = "untested")]
-pub(crate) const CB_OBJ_TAG_MAX: usize = CB_OBJ_TAG_MIN + 2; // 1 byte tag + 3 bytes len
-
-pub(crate) const TAG_ADMIN_FLAGS_1: u8 = 0x81;
-pub(crate) const TAG_ADMIN_SALT: u8 = 0x82;
-pub(crate) const TAG_ADMIN_TIMESTAMP: u8 = 0x83;
-pub(crate) const TAG_PROTECTED_FLAGS_1: u8 = 0x81;
-pub(crate) const TAG_PROTECTED_MGM: u8 = 0x89;
-
-/// PIV Applet ID
-pub(crate) const PIV_AID: [u8; 5] = [0xa0, 0x00, 0x00, 0x03, 0x08];
-
-/// MGMT Applet ID.
-///
-/// <https://developers.yubico.com/PIV/Introduction/Admin_access.html>
-#[cfg(feature = "untested")]
-pub(crate) const MGMT_AID: [u8; 8] = [0xa0, 0x00, 0x00, 0x05, 0x27, 0x47, 0x11, 0x17];
-
-/// YubiKey OTP Applet ID. Needed to query serial on YK4.
-pub(crate) const YK_AID: [u8; 8] = [0xa0, 0x00, 0x00, 0x05, 0x27, 0x20, 0x01, 0x01];

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -36,7 +36,7 @@ use zeroize::Zeroizing;
 use crate::{serialization::*, transaction::Transaction, Buffer, Error, Result};
 
 #[cfg(feature = "untested")]
-use crate::{CB_OBJ_MAX, CB_OBJ_TAG_MAX};
+use crate::consts::{CB_OBJ_MAX, CB_OBJ_TAG_MAX};
 
 #[cfg(feature = "untested")]
 use std::iter;

--- a/src/mgm.rs
+++ b/src/mgm.rs
@@ -38,30 +38,21 @@ use zeroize::{Zeroize, Zeroizing};
 
 #[cfg(feature = "untested")]
 use crate::{
+    consts::{TAG_ADMIN_FLAGS_1, TAG_ADMIN_SALT, TAG_PROTECTED_MGM},
     metadata::{AdminData, ProtectedData},
     yubikey::YubiKey,
-    TAG_ADMIN_FLAGS_1, TAG_ADMIN_SALT, TAG_PROTECTED_MGM,
 };
 use des::{
     cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt, NewBlockCipher},
     TdesEde3,
 };
 #[cfg(feature = "untested")]
-use hmac::Hmac;
-#[cfg(feature = "untested")]
-use pbkdf2::pbkdf2;
-#[cfg(feature = "untested")]
-use sha1::Sha1;
+use {hmac::Hmac, pbkdf2::pbkdf2, sha1::Sha1};
 
 pub(crate) const ADMIN_FLAGS_1_PROTECTED_MGM: u8 = 0x02;
 
 #[cfg(feature = "untested")]
 const CB_ADMIN_SALT: usize = 16;
-
-/// Default MGM key configured on all YubiKeys
-const DEFAULT_MGM_KEY: [u8; DES_LEN_3DES] = [
-    1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,
-];
 
 /// Size of a DES key
 const DES_LEN_DES: usize = 8;
@@ -349,9 +340,12 @@ impl AsRef<[u8; DES_LEN_3DES]> for MgmKey {
     }
 }
 
+/// Default MGM key configured on all YubiKeys
 impl Default for MgmKey {
     fn default() -> Self {
-        MgmKey(DEFAULT_MGM_KEY)
+        MgmKey([
+            1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,
+        ])
     }
 }
 

--- a/src/mscmap.rs
+++ b/src/mscmap.rs
@@ -30,7 +30,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{piv::SlotId, serialization::*, Error, Result, YubiKey, CB_OBJ_MAX};
+use crate::{consts::CB_OBJ_MAX, piv::SlotId, serialization::*, Error, Result, YubiKey};
 use log::error;
 use std::convert::{TryFrom, TryInto};
 

--- a/src/msroots.rs
+++ b/src/msroots.rs
@@ -30,8 +30,11 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{serialization::*, Error, Result, YubiKey};
-use crate::{CB_OBJ_MAX, CB_OBJ_TAG_MAX};
+use crate::{
+    consts::{CB_OBJ_MAX, CB_OBJ_TAG_MAX},
+    serialization::*,
+    Error, Result, YubiKey,
+};
 use log::error;
 
 const OBJ_MSROOTS1: u32 = 0x005f_ff11;

--- a/src/piv.rs
+++ b/src/piv.rs
@@ -59,7 +59,7 @@ use std::{convert::TryFrom, str::FromStr};
 
 #[cfg(feature = "untested")]
 use {
-    crate::CB_OBJ_MAX,
+    crate::consts::CB_OBJ_MAX,
     num_bigint_dig::traits::ModInverse,
     num_integer::Integer,
     num_traits::{FromPrimitive, One},

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -30,7 +30,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use crate::{Buffer, Error, ObjectId, Result, CB_OBJ_TAG_MIN};
+use crate::{consts::CB_OBJ_TAG_MIN, Buffer, Error, ObjectId, Result};
 
 pub const OBJ_DISCOVERY: u32 = 0x7e;
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -3,11 +3,12 @@
 use crate::{
     apdu::Response,
     apdu::{Apdu, Ins, StatusWords},
+    consts::{CB_BUF_MAX, CB_OBJ_MAX},
     error::{Error, Result},
     piv::{AlgorithmId, SlotId},
     serialization::*,
     yubikey::*,
-    Buffer, ObjectId, CB_BUF_MAX, CB_OBJ_MAX, PIV_AID, YK_AID,
+    Buffer, ObjectId,
 };
 use log::{error, trace};
 use std::convert::TryInto;
@@ -15,6 +16,12 @@ use zeroize::Zeroizing;
 
 #[cfg(feature = "untested")]
 use crate::mgm::{MgmKey, DES_LEN_3DES};
+
+/// PIV Applet ID
+const PIV_AID: [u8; 5] = [0xa0, 0x00, 0x00, 0x03, 0x08];
+
+/// YubiKey OTP Applet ID. Needed to query serial on YK4.
+const YK_AID: [u8; 8] = [0xa0, 0x00, 0x00, 0x05, 0x27, 0x20, 0x01, 0x01];
 
 const CB_PIN_MAX: usize = 8;
 

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -53,8 +53,11 @@ use std::{
 #[cfg(feature = "untested")]
 use {
     crate::{
-        apdu::StatusWords, metadata::AdminData, transaction::ChangeRefAction, Buffer, ObjectId,
-        MGMT_AID, TAG_ADMIN_FLAGS_1, TAG_ADMIN_TIMESTAMP,
+        apdu::StatusWords,
+        consts::{TAG_ADMIN_FLAGS_1, TAG_ADMIN_TIMESTAMP},
+        metadata::AdminData,
+        transaction::ChangeRefAction,
+        Buffer, ObjectId,
     },
     secrecy::ExposeSecret,
     std::time::{SystemTime, UNIX_EPOCH},
@@ -68,6 +71,12 @@ pub(crate) const ALGO_3DES: u8 = 0x03;
 
 /// Card management key
 pub(crate) const KEY_CARDMGM: u8 = 0x9b;
+
+/// MGMT Applet ID.
+///
+/// <https://developers.yubico.com/PIV/Introduction/Admin_access.html>
+#[cfg(feature = "untested")]
+const MGMT_AID: [u8; 8] = [0xa0, 0x00, 0x00, 0x05, 0x27, 0x47, 0x11, 0x17];
 
 const TAG_DYN_AUTH: u8 = 0x7c;
 


### PR DESCRIPTION
Extracts miscellaneous constants that were floating around in the toplevel into their own module.