### PR TITLE
yubikey v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (2021-03-22)
+## 0.4.0 (2021-07-12)
+### Added
+- `Result` alias ([#271])
+
+### Changed
+- Renamed crate from `yubikey-piv` => `yubikey` ([#267])
+- Renamed the following:
+    - `APDU` => `Apdu` ([#269])
+    - `CCC` => `Ccc` ([#269])
+    - `CHUID` => `ChuId` ([#269])
+    - `Ccc::cccid` => `Ccc::card_id` ([#270])
+    - `key` => `piv` ([#277])
+    - `readers` => `reader` ([#278])
+    - `readers::Readers` => `reader::Context` ([#278])
+- Bumped the following dependencies:
+  - `rsa` => v0.4 ([#246])
+  - `des` => v0.7 ([#251])
+  - `elliptic-curve` => v0.10 ([#268])
+  - `hmac` => v0.11 ([#251])
+  - `pbkdf2` => v0.8 ([#251])
+  - `p256` => v0.9 ([#268])
+  - `p384` => v0.8 ([#268])
+- MSRV 1.51+ ([#268])
+- Flatten API ([#274])
+- Replace `getrandom` with `rand_core` ([#276])
+
+### Fixed
+- Potential local DoS in TLV parser ([#279])
+
+[#246]: https://github.com/iqlusioninc/yubikey.rs/pull/246
+[#251]: https://github.com/iqlusioninc/yubikey.rs/pull/251
+[#267]: https://github.com/iqlusioninc/yubikey.rs/pull/267
+[#268]: https://github.com/iqlusioninc/yubikey.rs/pull/268
+[#269]: https://github.com/iqlusioninc/yubikey.rs/pull/269
+[#270]: https://github.com/iqlusioninc/yubikey.rs/pull/270
+[#271]: https://github.com/iqlusioninc/yubikey.rs/pull/271
+[#274]: https://github.com/iqlusioninc/yubikey.rs/pull/274
+[#276]: https://github.com/iqlusioninc/yubikey.rs/pull/276
+[#277]: https://github.com/iqlusioninc/yubikey.rs/pull/277
+[#278]: https://github.com/iqlusioninc/yubikey.rs/pull/278
+[#279]: https://github.com/iqlusioninc/yubikey.rs/pull/279
+
+## yubikey-piv 0.3.0 (2021-03-22)
 ### Added
 - Typed structs for PIN-protected and admin metadata ([#223])
 - `MgmKey::set_default`/`MgmKey::set_manual` methods ([#224])
@@ -18,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#223]: https://github.com/iqlusioninc/yubikey.rs/pull/223
 [#224]: https://github.com/iqlusioninc/yubikey.rs/pull/224
 
-## 0.2.0 (2021-01-30)
+## yubikey-piv 0.2.0 (2021-01-30)
 ### Changed
 - Bump `der-parser` to v5.0 ([#194])
 - Improve self-signed certificates ([#207])
@@ -32,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#208]: https://github.com/iqlusioninc/yubikey.rs/pull/208
 [#219]: https://github.com/iqlusioninc/yubikey.rs/pull/219
 
-## 0.1.0 (2020-10-19)
+## yubikey-piv 0.1.0 (2020-10-19)
 ### Added
 - `Certificate::generate_self_signed` ([#80])
 - `YubiKey::open_by_serial` ([#69])
@@ -74,7 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#61]: https://github.com/iqlusioninc/yubikey.rs/pull/61
 [#60]: https://github.com/iqlusioninc/yubikey.rs/pull/60
 
-## 0.0.3 (2019-12-02)
+## yubikey-piv 0.0.3 (2019-12-02)
 ### Added
 - Initial `Readers` enumerator for detecting YubiKeys ([#51])
 - Certificate parsing ([#45])
@@ -102,7 +144,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#33]: https://github.com/iqlusioninc/yubikey.rs/pull/33
 [#32]: https://github.com/iqlusioninc/yubikey.rs/pull/32
 
-## 0.0.2 (2019-11-25)
+## yubikey-piv 0.0.2 (2019-11-25)
 ### Added
 - `untested` Cargo feature to mark untested functionality ([#30])
 - Initial connect test and docs ([#19])
@@ -128,5 +170,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#7]: https://github.com/iqlusioninc/yubikey.rs/pull/7
 [#6]: https://github.com/iqlusioninc/yubikey.rs/pull/6
 
-## 0.0.1 (2019-11-18)
+## yubikey-piv 0.0.1 (2019-11-18)
 - Initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "cookie-factory",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-cli"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "env_logger",
  "gumdrop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name    = "yubikey"
-version = "0.4.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.0" # Also update html_root_url in lib.rs when bumping this
 description = """
-Pure Rust host-side driver for the YubiKey Personal Identity Verification (PIV)
-application providing general-purpose public-key signing and encryption
-with hardware-backed private keys for RSA (2048/1024) and ECC (P-256/P-384)
-algorithms (e.g, PKCS#1v1.5, ECDSA)
+Pure Rust cross-platform host-side driver for YubiKey devices from Yubico with
+support for hardware-backed public-key decryption and digital signatures using
+the Personal Identity Verification (PIV) application. Supports RSA (1024/2048)
+or ECC (NIST P-256/P-384) algorithms e.g, PKCS#1v1.5, ECDSA
 """
 authors    = ["Tony Arcieri <tony@iqlusion.io>", "Yubico AB"]
 edition    = "2018"
@@ -13,13 +13,10 @@ license    = "BSD-2-Clause"
 repository = "https://github.com/iqlusioninc/yubikey.rs"
 readme     = "README.md"
 categories = ["api-bindings", "cryptography", "hardware-support"]
-keywords   = ["ecdsa", "rsa", "piv", "pcsc", "yubikey"]
+keywords   = ["ecdsa", "encryption", "rsa", "piv", "signature"]
 
 [workspace]
 members = [".", "cli"]
-
-[badges]
-maintenance = { status = "experimental" }
 
 [dependencies]
 chrono = "0.4"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 [![Build Status][build-image]][build-link]
 [![Gitter Chat][gitter-image]][gitter-link]
 
-Pure Rust host-side YubiKey [Personal Identity Verification (PIV)][PIV] driver
-with general-purpose public-key encryption and signing support.
+Pure Rust cross-platform host-side driver for [YubiKey] devices from [Yubico]
+with support for public-key encryption and digital signatures using the
+[Personal Identity Verification (PIV)][PIV] application.
 
 [Documentation][docs-link]
 
@@ -45,6 +46,12 @@ Rust **1.51** or newer.
 
 NOTE: Nano and USB-C variants of the above are also supported.
       Pre-YK4 [YubiKey NEO] series is **NOT** supported (see [#18]).
+
+## Supported Operating Systems
+
+- Linux
+- macOS
+- Windows
 
 ## Security Warning
 
@@ -170,6 +177,7 @@ or conditions.
 
 [//]: # (general links)
 
+[YubiKey]: https://www.yubico.com/products/yubikey-hardware/
 [PIV]: https://piv.idmanagement.gov/
 [yk-guide]: https://developers.yubico.com/PIV/Introduction/YubiKey_and_PIV.html
 [Yubico]: https://www.yubico.com/

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-cli"
-version = "0.3.0"
+version = "0.4.0-pre"
 description = """
 Command-line interface for performing encryption and signing using RSA/ECC keys
 stored on YubiKey devices.
@@ -22,4 +22,4 @@ sha2 = "0.9"
 subtle-encoding = "0.5"
 termcolor = "1"
 x509-parser = "0.9"
-yubikey = { version = "=0.4.0-pre", path = ".." }
+yubikey = { version = "0.4", path = ".." }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,7 @@
 //! interface as provided by the [`pcsc` crate].
 //!
 //! # Features
-//!
 //! ## Personal Identity Verification (PIV)
-//!
 //! [PIV] is a [NIST] standard for both *signing* and *encryption*
 //! using SmartCards and SmartCard-based hardware tokens like YubiKeys.
 //!
@@ -19,19 +17,21 @@
 //! on which devices support PIV and the available functionality.
 //!
 //! # Minimum Supported Rust Version
-//!
 //! Rust **1.51** or newer.
 //!
 //! # Supported YubiKeys
-//!
 //! - [YubiKey 4] series
 //! - [YubiKey 5] series
 //!
 //! NOTE: Nano and USB-C variants of the above are also supported.
 //!       Pre-YK4 [YubiKey NEO] series is **NOT** supported.
 //!
-//! # Supported Algorithms
+//! # Supported Operating Systems
+//! - Linux
+//! - macOS
+//! - Windows
 //!
+//! # Supported Algorithms
 //! - **Authentication**: `3DES`
 //! - **Encryption**:
 //!   - RSA: `RSA1024`, `RSA2048`
@@ -43,7 +43,6 @@
 //! NOTE: RSASSA-PSS signatures and RSA-OAEP encryption may be supportable (TBD)
 //!
 //! # Status
-//!
 //! Functionality which has been successfully tested is available by default.
 //!
 //! Any functionality which is gated on the `untested` feature has not been
@@ -54,7 +53,6 @@
 //! `untested` gating as well as writing more automated tests.
 //!
 //! # History
-//!
 //! This library is a Rust translation of the [yubico-piv-tool] utility by
 //! Yubico, which was originally written in C. It was mechanically translated
 //! from C into Rust using [Corrode], and then subsequently heavily
@@ -65,20 +63,17 @@
 //! [Yubico PIV Tool Command Line Guide][piv-tool-guide].
 //!
 //! # Security Warning
-//!
 //! No security audits of this crate have ever been performed. Presently it is in
 //! an experimental stage and may still contain high-severity issues.
 //!
 //! USE AT YOUR OWN RISK!
 //!
 //! # Code of Conduct
-//!
 //! We abide by the [Contributor Covenant][cc-md] and ask that you do as well.
 //!
 //! For more information, please see [CODE_OF_CONDUCT.md][cc-md].
 //!
 //! # License
-//!
 //! **yubikey.rs** is a fork of and originally a mechanical translation from
 //! Yubico's [yubico-piv-tool], a C library/CLI program.
 //!
@@ -136,7 +131,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubikey.rs/main/img/logo.png",
-    html_root_url = "https://docs.rs/yubikey/0.4.0-pre"
+    html_root_url = "https://docs.rs/yubikey/0.4.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
### Added
- `Result` alias ([#271])

### Changed
- Renamed crate from `yubikey-piv` => `yubikey` ([#267])
- Renamed the following:
    - `APDU` => `Apdu` ([#269])
    - `CCC` => `Ccc` ([#269])
    - `CHUID` => `ChuId` ([#269])
    - `Ccc::cccid` => `Ccc::card_id` ([#270])
    - `key` => `piv` ([#277])
    - `readers` => `reader` ([#278])
    - `readers::Readers` => `reader::Context` ([#278])
- Bumped the following dependencies:
  - `rsa` => v0.4 ([#246])
  - `des` => v0.7 ([#251])
  - `elliptic-curve` => v0.10 ([#268])
  - `hmac` => v0.11 ([#251])
  - `pbkdf2` => v0.8 ([#251])
  - `p256` => v0.9 ([#268])
  - `p384` => v0.8 ([#268])
- MSRV 1.51+ ([#268])
- Flatten API ([#274])
- Replace `getrandom` with `rand_core` ([#276])

### Fixed
- Potential local DoS in TLV parser ([#279])

[#246]: https://github.com/iqlusioninc/yubikey.rs/pull/246
[#251]: https://github.com/iqlusioninc/yubikey.rs/pull/251
[#267]: https://github.com/iqlusioninc/yubikey.rs/pull/267
[#268]: https://github.com/iqlusioninc/yubikey.rs/pull/268
[#269]: https://github.com/iqlusioninc/yubikey.rs/pull/269
[#270]: https://github.com/iqlusioninc/yubikey.rs/pull/270
[#271]: https://github.com/iqlusioninc/yubikey.rs/pull/271
[#274]: https://github.com/iqlusioninc/yubikey.rs/pull/274
[#276]: https://github.com/iqlusioninc/yubikey.rs/pull/276
[#277]: https://github.com/iqlusioninc/yubikey.rs/pull/277
[#278]: https://github.com/iqlusioninc/yubikey.rs/pull/278
[#279]: https://github.com/iqlusioninc/yubikey.rs/pull/279