### PR TITLE
Rename `SettingValue` to `Setting`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ pub mod piv;
 mod policy;
 pub mod reader;
 mod serialization;
-mod settings;
+mod setting;
 mod transaction;
 mod yubikey;
 
@@ -167,7 +167,7 @@ pub use crate::{
     piv::Key,
     policy::{PinPolicy, TouchPolicy},
     reader::Context,
-    settings::{SettingSource, SettingValue},
+    setting::{Setting, SettingSource},
     yubikey::{CachedPin, Serial, Version, YubiKey},
 };
 

--- a/src/piv.rs
+++ b/src/piv.rs
@@ -48,7 +48,7 @@ use crate::{
     error::{Error, Result},
     policy::{PinPolicy, TouchPolicy},
     serialization::*,
-    settings,
+    setting,
     yubikey::YubiKey,
     Buffer, ObjectId,
 };
@@ -481,7 +481,7 @@ pub fn generate(
     const SZ_ROCA_BLOCK_ADMIN: &str = "was blocked due to an administrator configuration setting.";
     const SZ_ROCA_DEFAULT: &str = "was permitted by default, but is not recommended.  The default behavior will change in a future Yubico release.";
 
-    let setting_roca: settings::SettingValue;
+    let setting_roca: setting::Setting;
 
     match algorithm {
         AlgorithmId::Rsa1024 | AlgorithmId::Rsa2048 => {
@@ -489,17 +489,17 @@ pub fn generate(
                 && (yubikey.version.minor < 3
                     || yubikey.version.minor == 3 && (yubikey.version.patch < 5))
             {
-                setting_roca = settings::SettingValue::get(SZ_SETTING_ROCA, true);
+                setting_roca = setting::Setting::get(SZ_SETTING_ROCA, true);
 
                 let psz_msg = match setting_roca.source {
-                    settings::SettingSource::User => {
+                    setting::SettingSource::User => {
                         if setting_roca.value {
                             SZ_ROCA_ALLOW_USER
                         } else {
                             SZ_ROCA_BLOCK_USER
                         }
                     }
-                    settings::SettingSource::Admin => {
+                    setting::SettingSource::Admin => {
                         if setting_roca.value {
                             SZ_ROCA_ALLOW_ADMIN
                         } else {

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -66,7 +66,7 @@ impl Default for SettingSource {
 /// system administrator, or by the local user via `YUBIKEY_PIV_*` environment
 /// variables.
 #[derive(Copy, Clone, Debug)]
-pub struct SettingValue {
+pub struct Setting {
     /// Boolean value
     pub value: bool,
 
@@ -74,7 +74,7 @@ pub struct SettingValue {
     pub source: SettingSource,
 }
 
-impl SettingValue {
+impl Setting {
     /// Get a [`SettingValue`] value by name.
     pub fn get(key: &str, default: bool) -> Self {
         Self::from_file(key)
@@ -109,7 +109,7 @@ impl SettingValue {
                 };
 
                 if name == key {
-                    return Some(SettingValue {
+                    return Some(Setting {
                         source: SettingSource::Admin,
                         value: value == "1" || value == "true",
                     });
@@ -124,14 +124,14 @@ impl SettingValue {
     fn from_env(key: &str) -> Option<Self> {
         env::var(format!("YUBIKEY_PIV_{}", key))
             .ok()
-            .map(|value| SettingValue {
+            .map(|value| Setting {
                 source: SettingSource::User,
                 value: value == "1" || value == "true",
             })
     }
 }
 
-impl Default for SettingValue {
+impl Default for Setting {
     fn default() -> Self {
         Self {
             value: false,


### PR DESCRIPTION
Breaking change, but the crate is fresh and there's time to yank and republish.