### PR TITLE
yubikey v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.2 (2021-07-13)
+### Added
+- Make `yubikey::Buffer` a pub type ([#290])
+
+### Changed
+- Have `YubiKey::block_puk` take `&mut self` as argument ([#289])
+
+[#289]: https://github.com/iqlusioninc/yubikey.rs/pull/289
+[#290]: https://github.com/iqlusioninc/yubikey.rs/pull/290
+
 ## 0.4.1 (2021-07-12)
 ### Changed
 - Rename `SettingValue` to `Setting` ([#286])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "cookie-factory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "yubikey"
-version = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.4.2" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust cross-platform host-side driver for YubiKey devices from Yubico with
 support for hardware-backed public-key decryption and digital signatures using

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubikey.rs/main/img/logo.png",
-    html_root_url = "https://docs.rs/yubikey/0.4.1"
+    html_root_url = "https://docs.rs/yubikey/0.4.2"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
### Added
- Make `yubikey::Buffer` a pub type ([#290])

### Changed
- Have `YubiKey::block_puk` take `&mut self` as argument ([#289])

[#289]: https://github.com/iqlusioninc/yubikey.rs/pull/289
[#290]: https://github.com/iqlusioninc/yubikey.rs/pull/290