### PR TITLE
yubikey v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2021-11-21)
+### Changed
+- Update `rsa` dependency to 0.5 ([#315])
+- Update `pbkdf2` dependency to 0.9 ([#315])
+- Update `x509-parser` dependency to 0.11 ([#315])
+- Update `nom` to v7.0 ([#322])
+
+[#315]: https://github.com/iqlusioninc/yubikey.rs/pull/315
+[#322]: https://github.com/iqlusioninc/yubikey.rs/pull/322
+
 ## 0.4.2 (2021-07-13)
 ### Added
 - Make `yubikey::Buffer` a pub type ([#290])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `rsa` dependency to 0.5 ([#315])
 - Update `pbkdf2` dependency to 0.9 ([#315])
-- Update `x509-parser` dependency to 0.11 ([#315])
+- Update `x509-parser` dependency to 0.12 ([#315], [#322])
 - Update `nom` to v7.0 ([#322])
 
 [#315]: https://github.com/iqlusioninc/yubikey.rs/pull/315

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "cookie-factory",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-cli"
-version = "0.4.0"
+version = "0.5.0-pre"
 dependencies = [
  "env_logger",
  "gumdrop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "yubikey"
-version = "0.4.2" # Also update html_root_url in lib.rs when bumping this
+version = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Pure Rust cross-platform host-side driver for YubiKey devices from Yubico with
 support for hardware-backed public-key decryption and digital signatures using

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `status` command ([#72], [#74])
 
 ### Changed
-- Bump `yubikey-piv` to v0.1.0 ([#180])
+- Bump `yubikey-piv` to v0.1 ([#180])
 - Bump `x509-parser` to v0.8 ([#181])
 - Bump `sha2` to v0.9 ([#182])
 - Rename `list` command to `readers`; improve usage ([#71])

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-cli"
-version = "0.4.0"
+version = "0.5.0-pre"
 description = """
 Command-line interface for performing encryption and signing using RSA/ECC keys
 stored on YubiKey devices.
@@ -22,4 +22,4 @@ sha2 = "0.9"
 subtle-encoding = "0.5"
 termcolor = "1"
 x509-parser = "0.12"
-yubikey = { version = "0.4", path = ".." }
+yubikey = { version = "0.5", path = ".." }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/yubikey.rs/main/img/logo.png",
-    html_root_url = "https://docs.rs/yubikey/0.4.2"
+    html_root_url = "https://docs.rs/yubikey/0.5.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Update `rsa` dependency to 0.5 ([#315])
- Update `pbkdf2` dependency to 0.9 ([#315])
- Update `x509-parser` dependency to 0.12 ([#315], [#322])
- Update `nom` to v7.0 ([#322])

[#315]: https://github.com/iqlusioninc/yubikey.rs/pull/315
[#322]: https://github.com/iqlusioninc/yubikey.rs/pull/322