### PR TITLE
yubikey-cli v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-cli"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "env_logger",
  "gumdrop",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2021-11-21)
+### Changed
+- Bump `yubikey` dependency to v0.5 ([#327])
+
+[#327]: https://github.com/iqlusioninc/yubikey.rs/pull/327
+ 
 ## 0.4.0 (2021-07-12)
 ### Changed
 - Switch to renamed `yubikey` crate ([#283])

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-cli"
-version = "0.5.0-pre"
+version = "0.5.0"
 description = """
 Command-line interface for performing encryption and signing using RSA/ECC keys
 stored on YubiKey devices.


### PR DESCRIPTION
### Changed
- Bump `yubikey` dependency to v0.5 ([#327])

[#327]: https://github.com/iqlusioninc/yubikey.rs/pull/327