### PR TITLE
Add display formatter to serial

### DIFF
--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -47,8 +47,8 @@ use p256::NistP256;
 use p384::NistP384;
 use rsa::{PublicKeyParts, RsaPublicKey};
 use sha2::{Digest, Sha256};
+use std::fmt::{format, Display, Formatter};
 use std::{fmt, ops::DerefMut};
-use std::fmt::{Display, format, Formatter};
 use x509::{der::Oid, RelativeDistinguishedName};
 use x509_parser::{parse_x509_certificate, x509::SubjectPublicKeyInfo};
 use zeroize::Zeroizing;
@@ -101,18 +101,18 @@ impl Serial {
     pub fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes_be()
     }
-    pub fn as_x509_hex(&self) -> String{
+    pub fn as_x509_hex(&self) -> String {
         let data = self.to_bytes();
         let raw_hex_string = format!("{:02X?}", data);
         raw_hex_string
             .replace(", ", ":")
-            .replace("]","")
-            .replace("[","")
+            .replace("]", "")
+            .replace("[", "")
             .to_lowercase()
     }
-    pub fn as_x509_int(&self) -> String{
+    pub fn as_x509_int(&self) -> String {
         let Serial(buint) = self;
-        format!("{}",buint)
+        format!("{}", buint)
     }
 }
 

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -48,6 +48,7 @@ use p384::NistP384;
 use rsa::{PublicKeyParts, RsaPublicKey};
 use sha2::{Digest, Sha256};
 use std::{fmt, ops::DerefMut};
+use std::fmt::{Display, format, Formatter};
 use x509::{der::Oid, RelativeDistinguishedName};
 use x509_parser::{parse_x509_certificate, x509::SubjectPublicKeyInfo};
 use zeroize::Zeroizing;
@@ -90,9 +91,28 @@ impl TryFrom<&[u8]> for Serial {
     }
 }
 
+impl Display for Serial {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.as_x509_hex())
+    }
+}
+
 impl Serial {
-    fn to_bytes(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes_be()
+    }
+    pub fn as_x509_hex(&self) -> String{
+        let data = self.to_bytes();
+        let raw_hex_string = format!("{:02X?}", data);
+        raw_hex_string
+            .replace(", ", ":")
+            .replace("]","")
+            .replace("[","")
+            .to_lowercase()
+    }
+    pub fn as_x509_int(&self) -> String{
+        let Serial(buint) = self;
+        format!("{}",buint)
     }
 }
 

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -98,9 +98,11 @@ impl Display for Serial {
 }
 
 impl Serial {
+    /// Returns itself as vector of big endian bytes
     pub fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes_be()
     }
+    /// Returns itself formatted as x509 compatible hex string
     pub fn as_x509_hex(&self) -> String {
         let data = self.to_bytes();
         let raw_hex_string = format!("{:02X?}", data);
@@ -110,6 +112,7 @@ impl Serial {
             .replace("[", "")
             .to_lowercase()
     }
+    /// Returns itself formatted as x509 compatible int string
     pub fn as_x509_int(&self) -> String {
         let Serial(buint) = self;
         format!("{}", buint)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,14 +3,11 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
-use cookie_factory::combinator::hex;
-use cookie_factory::gen;
 use lazy_static::lazy_static;
 use log::trace;
 use rand_core::{OsRng, RngCore};
 use rsa::{hash::Hash::SHA2_256, PaddingScheme, PublicKey};
 use sha2::{Digest, Sha256};
-use std::fmt::format;
 use std::{env, sync::Mutex};
 use x509::RelativeDistinguishedName;
 use yubikey::certificate::Serial;
@@ -250,7 +247,7 @@ fn generate_self_signed_ec_cert() {
 #[ignore]
 fn test_serial_string_conversions() {
     //2^152+1
-    let mut serial: [u8; 20] = [
+    let serial: [u8; 20] = [
         0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x01,
     ];
@@ -265,7 +262,7 @@ fn test_serial_string_conversions() {
         "01:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01"
     );
 
-    let mut serial2: [u8; 20] = [
+    let serial2: [u8; 20] = [
         0xA1, 0xF3, 0x02, 0x30, 0x76, 0x01, 0x32, 0x48, 0x09, 0x9C, 0x10, 0xAA, 0x3F, 0xA0, 0x54,
         0x0D, 0xC0, 0xB7, 0x65, 0x01,
     ];
@@ -280,7 +277,7 @@ fn test_serial_string_conversions() {
         "a1:f3:02:30:76:01:32:48:09:9c:10:aa:3f:a0:54:0d:c0:b7:65:01"
     );
 
-    let mut serial3: [u8; 20] = [
+    let serial3: [u8; 20] = [
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAA, 0x3F, 0xA0, 0x54,
         0x0D, 0xC0, 0xB7, 0x65, 0x01,
     ];

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,12 +9,16 @@ use rand_core::{OsRng, RngCore};
 use rsa::{hash::Hash::SHA2_256, PaddingScheme, PublicKey};
 use sha2::{Digest, Sha256};
 use std::{env, sync::Mutex};
+use std::fmt::format;
+use cookie_factory::combinator::hex;
+use cookie_factory::gen;
 use x509::RelativeDistinguishedName;
 use yubikey::{
     certificate::{Certificate, PublicKeyInfo},
     piv::{self, AlgorithmId, Key, RetiredSlotId, SlotId},
     Error, MgmKey, PinPolicy, TouchPolicy, YubiKey,
 };
+use yubikey::certificate::Serial;
 
 lazy_static! {
     /// Provide thread-safe access to a YubiKey
@@ -240,4 +244,93 @@ fn generate_self_signed_ec_cert() {
 
     use p256::ecdsa::signature::Verifier;
     assert!(vk.verify(msg, &sig).is_ok());
+}
+
+#[test]
+#[ignore]
+fn test_serial_string_conversions(){
+    //2^152+1
+    let mut serial:[u8; 20] = [
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+    ];
+
+    let s: Serial = Serial::from(serial);
+    assert_eq!(s.as_x509_int(),"5708990770823839524233143877797980545530986497");
+    assert_eq!(s.as_x509_hex(), "01:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01");
+
+    let mut serial2:[u8; 20] = [
+        0xA1,
+        0xF3,
+        0x02,
+        0x30,
+        0x76,
+        0x01,
+        0x32,
+        0x48,
+        0x09,
+        0x9C,
+        0x10,
+        0xAA,
+        0x3F,
+        0xA0,
+        0x54,
+        0x0D,
+        0xC0,
+        0xB7,
+        0x65,
+        0x01,
+    ];
+
+
+    let s2: Serial = Serial::from(serial2);
+    assert_eq!(s2.as_x509_int(),"924566785900861696177829411010986812227211191553");
+    assert_eq!(s2.as_x509_hex(), "a1:f3:02:30:76:01:32:48:09:9c:10:aa:3f:a0:54:0d:c0:b7:65:01");
+
+
+    let mut serial3:[u8; 20] = [
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0xAA,
+        0x3F,
+        0xA0,
+        0x54,
+        0x0D,
+        0xC0,
+        0xB7,
+        0x65,
+        0x01,
+    ];
+
+    let s3: Serial = Serial::from(serial3);
+    assert_eq!(s3.as_x509_int(),"3140531249369331492097");
+    assert_eq!(s3.as_x509_hex(), "aa:3f:a0:54:0d:c0:b7:65:01");
+
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,22 +3,22 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, trivial_casts, unused_qualifications)]
 
+use cookie_factory::combinator::hex;
+use cookie_factory::gen;
 use lazy_static::lazy_static;
 use log::trace;
 use rand_core::{OsRng, RngCore};
 use rsa::{hash::Hash::SHA2_256, PaddingScheme, PublicKey};
 use sha2::{Digest, Sha256};
-use std::{env, sync::Mutex};
 use std::fmt::format;
-use cookie_factory::combinator::hex;
-use cookie_factory::gen;
+use std::{env, sync::Mutex};
 use x509::RelativeDistinguishedName;
+use yubikey::certificate::Serial;
 use yubikey::{
     certificate::{Certificate, PublicKeyInfo},
     piv::{self, AlgorithmId, Key, RetiredSlotId, SlotId},
     Error, MgmKey, PinPolicy, TouchPolicy, YubiKey,
 };
-use yubikey::certificate::Serial;
 
 lazy_static! {
     /// Provide thread-safe access to a YubiKey
@@ -248,89 +248,44 @@ fn generate_self_signed_ec_cert() {
 
 #[test]
 #[ignore]
-fn test_serial_string_conversions(){
+fn test_serial_string_conversions() {
     //2^152+1
-    let mut serial:[u8; 20] = [
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
+    let mut serial: [u8; 20] = [
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x01,
     ];
 
     let s: Serial = Serial::from(serial);
-    assert_eq!(s.as_x509_int(),"5708990770823839524233143877797980545530986497");
-    assert_eq!(s.as_x509_hex(), "01:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01");
+    assert_eq!(
+        s.as_x509_int(),
+        "5708990770823839524233143877797980545530986497"
+    );
+    assert_eq!(
+        s.as_x509_hex(),
+        "01:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01"
+    );
 
-    let mut serial2:[u8; 20] = [
-        0xA1,
-        0xF3,
-        0x02,
-        0x30,
-        0x76,
-        0x01,
-        0x32,
-        0x48,
-        0x09,
-        0x9C,
-        0x10,
-        0xAA,
-        0x3F,
-        0xA0,
-        0x54,
-        0x0D,
-        0xC0,
-        0xB7,
-        0x65,
-        0x01,
+    let mut serial2: [u8; 20] = [
+        0xA1, 0xF3, 0x02, 0x30, 0x76, 0x01, 0x32, 0x48, 0x09, 0x9C, 0x10, 0xAA, 0x3F, 0xA0, 0x54,
+        0x0D, 0xC0, 0xB7, 0x65, 0x01,
     ];
 
-
     let s2: Serial = Serial::from(serial2);
-    assert_eq!(s2.as_x509_int(),"924566785900861696177829411010986812227211191553");
-    assert_eq!(s2.as_x509_hex(), "a1:f3:02:30:76:01:32:48:09:9c:10:aa:3f:a0:54:0d:c0:b7:65:01");
+    assert_eq!(
+        s2.as_x509_int(),
+        "924566785900861696177829411010986812227211191553"
+    );
+    assert_eq!(
+        s2.as_x509_hex(),
+        "a1:f3:02:30:76:01:32:48:09:9c:10:aa:3f:a0:54:0d:c0:b7:65:01"
+    );
 
-
-    let mut serial3:[u8; 20] = [
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0xAA,
-        0x3F,
-        0xA0,
-        0x54,
-        0x0D,
-        0xC0,
-        0xB7,
-        0x65,
-        0x01,
+    let mut serial3: [u8; 20] = [
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAA, 0x3F, 0xA0, 0x54,
+        0x0D, 0xC0, 0xB7, 0x65, 0x01,
     ];
 
     let s3: Serial = Serial::from(serial3);
-    assert_eq!(s3.as_x509_int(),"3140531249369331492097");
+    assert_eq!(s3.as_x509_int(), "3140531249369331492097");
     assert_eq!(s3.as_x509_hex(), "aa:3f:a0:54:0d:c0:b7:65:01");
-
 }


### PR DESCRIPTION
This pr extends serial, to provide a std::fmt::Display formatter to yubikey::certificate::Serial.

It also provides an numeric formatter and exports to_bytes, to allow other libraries easier handling of Serials.