### PR TITLE
Add Display formatter to SlotId

### DIFF
--- a/src/piv.rs
+++ b/src/piv.rs
@@ -158,7 +158,7 @@ impl Display for SlotId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             SlotId::Retired(r) => write!(f, "{:?}", r),
-            _ => write!(f, "{:?}", self)
+            _ => write!(f, "{:?}", self),
         }
     }
 }

--- a/src/piv.rs
+++ b/src/piv.rs
@@ -157,14 +157,8 @@ impl From<SlotId> for u8 {
 impl Display for SlotId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            SlotId::Authentication => f.write_str("Authentication"),
-            SlotId::Signature => f.write_str("Signature"),
-            SlotId::KeyManagement => f.write_str("KeyManagement"),
-            SlotId::CardAuthentication => f.write_str("CardAuthentication"),
-            SlotId::Retired(r) => {
-                write!(f, "{}", r)
-            }
-            SlotId::Attestation => f.write_str("Attestation"),
+            SlotId::Retired(r) => write!(f, "{:?}", r),
+            _ => write!(f, "{:?}", self)
         }
     }
 }
@@ -313,72 +307,7 @@ impl From<RetiredSlotId> for u8 {
 
 impl Display for RetiredSlotId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                RetiredSlotId::R1 => {
-                    "R1"
-                }
-                RetiredSlotId::R2 => {
-                    "R2"
-                }
-                RetiredSlotId::R3 => {
-                    "R3"
-                }
-                RetiredSlotId::R4 => {
-                    "R4"
-                }
-                RetiredSlotId::R5 => {
-                    "R5"
-                }
-                RetiredSlotId::R6 => {
-                    "R6"
-                }
-                RetiredSlotId::R7 => {
-                    "R7"
-                }
-                RetiredSlotId::R8 => {
-                    "R8"
-                }
-                RetiredSlotId::R9 => {
-                    "R9"
-                }
-                RetiredSlotId::R10 => {
-                    "R10"
-                }
-                RetiredSlotId::R11 => {
-                    "R11"
-                }
-                RetiredSlotId::R12 => {
-                    "R12"
-                }
-                RetiredSlotId::R13 => {
-                    "R13"
-                }
-                RetiredSlotId::R14 => {
-                    "R14"
-                }
-                RetiredSlotId::R15 => {
-                    "R15"
-                }
-                RetiredSlotId::R16 => {
-                    "R16"
-                }
-                RetiredSlotId::R17 => {
-                    "R17"
-                }
-                RetiredSlotId::R18 => {
-                    "R18"
-                }
-                RetiredSlotId::R19 => {
-                    "R19"
-                }
-                RetiredSlotId::R20 => {
-                    "R20"
-                }
-            }
-        )
+        write!(f, "{:?}", self)
     }
 }
 

--- a/src/piv.rs
+++ b/src/piv.rs
@@ -57,6 +57,7 @@ use log::{debug, error, warn};
 use p256::NistP256;
 use p384::NistP384;
 use rsa::{BigUint, RsaPublicKey};
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 #[cfg(feature = "untested")]
@@ -149,6 +150,21 @@ impl From<SlotId> for u8 {
             SlotId::CardAuthentication => 0x9e,
             SlotId::Retired(retired) => retired.into(),
             SlotId::Attestation => 0xf9,
+        }
+    }
+}
+
+impl Display for SlotId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SlotId::Authentication => f.write_str("Authentication"),
+            SlotId::Signature => f.write_str("Signature"),
+            SlotId::KeyManagement => f.write_str("KeyManagement"),
+            SlotId::CardAuthentication => f.write_str("CardAuthentication"),
+            SlotId::Retired(r) => {
+                write!(f, "{}", r)
+            }
+            SlotId::Attestation => f.write_str("Attestation"),
         }
     }
 }
@@ -292,6 +308,77 @@ impl From<RetiredSlotId> for u8 {
             RetiredSlotId::R19 => 0x94,
             RetiredSlotId::R20 => 0x95,
         }
+    }
+}
+
+impl Display for RetiredSlotId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                RetiredSlotId::R1 => {
+                    "R1"
+                }
+                RetiredSlotId::R2 => {
+                    "R2"
+                }
+                RetiredSlotId::R3 => {
+                    "R3"
+                }
+                RetiredSlotId::R4 => {
+                    "R4"
+                }
+                RetiredSlotId::R5 => {
+                    "R5"
+                }
+                RetiredSlotId::R6 => {
+                    "R6"
+                }
+                RetiredSlotId::R7 => {
+                    "R7"
+                }
+                RetiredSlotId::R8 => {
+                    "R8"
+                }
+                RetiredSlotId::R9 => {
+                    "R9"
+                }
+                RetiredSlotId::R10 => {
+                    "R10"
+                }
+                RetiredSlotId::R11 => {
+                    "R11"
+                }
+                RetiredSlotId::R12 => {
+                    "R12"
+                }
+                RetiredSlotId::R13 => {
+                    "R13"
+                }
+                RetiredSlotId::R14 => {
+                    "R14"
+                }
+                RetiredSlotId::R15 => {
+                    "R15"
+                }
+                RetiredSlotId::R16 => {
+                    "R16"
+                }
+                RetiredSlotId::R17 => {
+                    "R17"
+                }
+                RetiredSlotId::R18 => {
+                    "R18"
+                }
+                RetiredSlotId::R19 => {
+                    "R19"
+                }
+                RetiredSlotId::R20 => {
+                    "R20"
+                }
+            }
+        )
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -241,3 +241,36 @@ fn generate_self_signed_ec_cert() {
     use p256::ecdsa::signature::Verifier;
     assert!(vk.verify(msg, &sig).is_ok());
 }
+
+#[test]
+#[ignore]
+fn test_slot_id_display() {
+    assert_eq!(format!("{}", SlotId::Authentication), "Authentication");
+    assert_eq!(format!("{}", SlotId::Signature), "Signature");
+    assert_eq!(format!("{}", SlotId::KeyManagement), "KeyManagement");
+    assert_eq!(
+        format!("{}", SlotId::CardAuthentication),
+        "CardAuthentication"
+    );
+    assert_eq!(format!("{}", SlotId::Attestation), "Attestation");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R1)), "R1");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R2)), "R2");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R3)), "R3");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R4)), "R4");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R5)), "R5");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R6)), "R6");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R7)), "R7");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R8)), "R8");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R9)), "R9");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R10)), "R10");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R11)), "R11");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R12)), "R12");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R13)), "R13");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R14)), "R14");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R15)), "R15");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R16)), "R16");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R17)), "R17");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R18)), "R18");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R19)), "R19");
+    assert_eq!(format!("{}", SlotId::Retired(RetiredSlotId::R20)), "R20");
+}


### PR DESCRIPTION
This pr extends SlotId, to provide a std::fmt::Display formatter to yubikey::certificate::SlotId.