### PR TITLE
Adding some common traits for certain enum types to support maps.

### DIFF
--- a/src/piv.rs
+++ b/src/piv.rs
@@ -86,7 +86,7 @@ const KEYDATA_RSA_EXP: u64 = 65537;
 
 /// Slot identifiers.
 /// <https://developers.yubico.com/PIV/Introduction/Certificate_slots.html>
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub enum SlotId {
     /// This certificate and its associated private key is used to authenticate the card
     /// and the cardholder. This slot is used for things like system login. The end user
@@ -194,7 +194,7 @@ impl SlotId {
 
 /// Retired slot IDs.
 #[allow(missing_docs)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum RetiredSlotId {
     R1,
     R2,


### PR DESCRIPTION
Would you be open to adding these?

SlotId in particular is useful as a key in map types.  There may be other enums that could benefit from additional derived traits, though these two (SlotId and RetiredSlotId) are sufficient for my own use case.  For most of the enums it seems like there's no reason not to implement Eq, Ord, and PartialOrd at least.  I could understand not wanting to provide Hash if it was costly in a very-small-code environment.