### PR TITLE
yubikey v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2022-08-10)
+### Changed
+- 2021 edition upgrade ([#343])
+- RustCrypto crate upgrades; MSRV 1.57 ([#378])
+  - `des` v0.8
+  - `elliptic-curve` v0.12
+  - `hmac` v0.12
+  - `num-bigint-dig` v0.8
+  - `pbkdf2` v0.11
+  - `p256` v0.11
+  - `p384` v0.11
+  - `rsa` v0.6
+  - `sha1` v0.10 (replacing `sha-1`)
+  - `sha2` v0.10
+- Bump `uuid` to v1.0 ([#376])
+- Bump `der-parser` to v8.0 ([#402])
+- Bump `x509-parser` to v0.14 ([#402])
+
+[#343]: https://github.com/iqlusioninc/yubikey.rs/pull/343
+[#376]: https://github.com/iqlusioninc/yubikey.rs/pull/376
+[#378]: https://github.com/iqlusioninc/yubikey.rs/pull/378
+[#402]: https://github.com/iqlusioninc/yubikey.rs/pull/402
+
 ## 0.5.0 (2021-11-21)
 ### Changed
 - Update `rsa` dependency to 0.5 ([#315])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "cookie-factory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey"
-version = "0.6.0-pre" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.0"
 description = """
 Pure Rust cross-platform host-side driver for YubiKey devices from Yubico with
 support for hardware-backed public-key decryption and digital signatures using

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,4 +23,4 @@ sha2 = "0.9"
 subtle-encoding = "0.5"
 termcolor = "1"
 x509-parser = "0.12"
-yubikey = { version = "=0.6.0-pre", path = ".." }
+yubikey = { version = "0.6", path = ".." }


### PR DESCRIPTION
### Changed
- 2021 edition upgrade ([#343])
- RustCrypto crate upgrades; MSRV 1.57 ([#378])
  - `des` v0.8
  - `elliptic-curve` v0.12
  - `hmac` v0.12
  - `num-bigint-dig` v0.8
  - `pbkdf2` v0.11
  - `p256` v0.11
  - `p384` v0.11
  - `rsa` v0.6
  - `sha1` v0.10 (replacing `sha-1`)
  - `sha2` v0.10
- Bump `uuid` to v1.0 ([#376])
- Bump `der-parser` to v8.0 ([#402])
- Bump `x509-parser` to v0.14 ([#402])

[#343]: https://github.com/iqlusioninc/yubikey.rs/pull/343
[#376]: https://github.com/iqlusioninc/yubikey.rs/pull/376
[#378]: https://github.com/iqlusioninc/yubikey.rs/pull/378
[#402]: https://github.com/iqlusioninc/yubikey.rs/pull/402