### PR TITLE
yubikey-cli v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "yubikey-cli"
-version = "0.6.0-pre"
+version = "0.6.0"
 dependencies = [
  "clap",
  "env_logger",

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Yubico's [yubico-piv-tool], a C library/CLI program. The original library
 was licensed under a [2-Clause BSD License][BSDL], which this library inherits
 as a derived work.
 
-Copyright (c) 2014-2021 Yubico AB, Tony Arcieri
+Copyright (c) 2014-2022 Yubico AB, Tony Arcieri
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 (2022-08-10)
+### Changed
+- 2021 edition upgrade; MSRV 1.57 ([#343])
+- Migrate from `gumdrop` to `clap` v3 ([#379])
+- Bump `yubikey` dependency to v0.6 ([#403])
+
+[#343]: https://github.com/iqlusioninc/yubikey.rs/pull/343
+[#379]: https://github.com/iqlusioninc/yubikey.rs/pull/379
+[#403]: https://github.com/iqlusioninc/yubikey.rs/pull/403
+
 ## 0.5.0 (2021-11-21)
 ### Changed
 - Bump `yubikey` dependency to v0.5 ([#327])

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yubikey-cli"
-version = "0.6.0-pre"
+version = "0.6.0"
 description = """
 Command-line interface for performing encryption and signing using RSA/ECC keys
 stored on YubiKey devices.

--- a/cli/README.md
+++ b/cli/README.md
@@ -18,7 +18,7 @@ utility with general-purpose public-key encryption and signing support.
 
 ## Minimum Supported Rust Version
 
-Rust **1.51** or newer.
+Rust **1.57** or newer.
 
 ## Supported YubiKeys
 
@@ -35,10 +35,6 @@ an experimental stage and may still contain high-severity issues.
 
 USE AT YOUR OWN RISK!
 
-## Status
-
-WIP. Check back later.
-
 ## Code of Conduct
 
 We abide by the [Contributor Covenant][cc-md] and ask that you do as well.
@@ -47,7 +43,7 @@ For more information, please see [CODE_OF_CONDUCT.md][cc-md].
 
 ## License
 
-Copyright (c) 2014-2021 Yubico AB, Tony Arcieri
+Copyright (c) 2014-2022 Yubico AB, Tony Arcieri
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -88,7 +84,7 @@ or conditions.
 [docs-image]: https://docs.rs/yubikey-cli/badge.svg
 [docs-link]: https://docs.rs/yubikey-cli/
 [license-image]: https://img.shields.io/badge/license-BSD-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.39+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.57+-blue.svg
 [maintenance-image]: https://img.shields.io/badge/maintenance-experimental-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/


### PR DESCRIPTION
### Changed
- 2021 edition upgrade; MSRV 1.57 ([#343])
- Migrate from `gumdrop` to `clap` v3 ([#379])
- Bump `yubikey` dependency to v0.6 ([#403])

[#343]: https://github.com/iqlusioninc/yubikey.rs/pull/343
[#379]: https://github.com/iqlusioninc/yubikey.rs/pull/379
[#403]: https://github.com/iqlusioninc/yubikey.rs/pull/403