### PR TITLE
Use `chrono` v0.4.23 or newer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.57"
 members = [".", "cli"]
 
 [dependencies]
-chrono = "0.4"
+chrono = "0.4.23"
 cookie-factory = "0.3"
 der-parser = "8"
 des = "0.8"


### PR DESCRIPTION
Addresses [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159.html)