### PR TITLE
Add partial `Debug` impls for `Context` and `YubiKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `impl Debug for {Context, YubiKey}`
+
 ## 0.7.0 (2022-11-14)
 ### Added
 - Display inner PC/SC errors ([#420])

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4,6 +4,7 @@ use crate::{Result, YubiKey};
 use std::{
     borrow::Cow,
     ffi::CStr,
+    fmt,
     sync::{Arc, Mutex},
 };
 
@@ -17,6 +18,12 @@ pub struct Context {
 
     /// Buffer for storing reader names
     reader_names: Vec<u8>,
+}
+
+impl fmt::Debug for Context {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Context").finish_non_exhaustive()
+    }
 }
 
 impl Context {

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -156,6 +156,16 @@ pub struct YubiKey {
     pub(crate) serial: Serial,
 }
 
+impl fmt::Debug for YubiKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("YubiKey")
+            .field("name", &self.name)
+            .field("version", &self.version)
+            .field("serial", &self.serial)
+            .finish_non_exhaustive()
+    }
+}
+
 impl YubiKey {
     /// Open a connection to a YubiKey.
     ///


### PR DESCRIPTION
This enables `yubikey::Result<T>` to be debug-formatted, for example when wrapping the output of an API method in `dbg!()`.