### PR TITLE
transaction: comment cleanup in `get_serial`

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Yubico's [yubico-piv-tool], a C library/CLI program. The original library
 was licensed under a [2-Clause BSD License][BSDL], which this library inherits
 as a derived work.
 
-Copyright (c) 2014-2022 Yubico AB, Tony Arcieri
+Copyright (c) 2014-2023 Yubico AB, Tony Arcieri
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/cli/README.md
+++ b/cli/README.md
@@ -43,7 +43,7 @@ For more information, please see [CODE_OF_CONDUCT.md][cc-md].
 
 ## License
 
-Copyright (c) 2014-2022 Yubico AB, Tony Arcieri
+Copyright (c) 2014-2023 Yubico AB, Tony Arcieri
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Moves comments about each YubiKey version number above the arms of the `match` expression