### PR TITLE
Return errors from `YubiKey::open_by_serial` that indicate a key may exist

### DIFF
--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -242,6 +242,9 @@ impl YubiKey {
 
             if serial == yubikey.serial() {
                 return Ok(yubikey);
+            } else {
+                // We didn't want this YubiKey; don't reset it.
+                let _ = yubikey.disconnect(pcsc::Disposition::LeaveCard);
             }
         }
 


### PR DESCRIPTION
The only such error at the moment is `pcsc::Error::SharingViolation`, which indicates a transient failure to access a specific reader that could have been the one we needed (and so a future retry might succeed).

Closes iqlusioninc/yubikey.rs#458.