### PR TITLE
Raise minimum `pcsc` version to remove workaround

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ num-integer = "0.1"
 pbkdf2 = { version = "0.11", default-features = false }
 p256 = "0.11"
 p384 = "0.11"
-pcsc = "2"
+pcsc = "2.3.1"
 rand_core = { version = "0.6", features = ["std"] }
 rsa = "0.7"
 secrecy = "0.8"

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -190,12 +190,7 @@ impl YubiKey {
     /// [`yubikey::reader::Context`][`Context`] to select from the available
     /// PC/SC readers.
     pub fn open() -> Result<Self> {
-        let mut readers = Context::open().map_err(|e| match e {
-            Error::PcscError {
-                inner: Some(pcsc::Error::NoReadersAvailable),
-            } => Error::NotFound,
-            other => other,
-        })?;
+        let mut readers = Context::open()?;
         let mut reader_iter = readers.iter()?;
 
         if let Some(reader) = reader_iter.next() {
@@ -213,12 +208,7 @@ impl YubiKey {
 
     /// Open a YubiKey with a specific serial number.
     pub fn open_by_serial(serial: Serial) -> Result<Self> {
-        let mut readers = Context::open().map_err(|e| match e {
-            Error::PcscError {
-                inner: Some(pcsc::Error::NoReadersAvailable),
-            } => Error::NotFound,
-            other => other,
-        })?;
+        let mut readers = Context::open()?;
 
         for reader in readers.iter()? {
             let yubikey = match reader.open() {


### PR DESCRIPTION
In iqlusioninc/yubikey.rs#88 we added a workaround for what turned out to be a bug in `pcsc`, where an error was returned if no readers were available, instead of returning an empty iterator. `pcsc 2.3.1` was published in 2019, so we can safely rely on it.