### PR TITLE
implement yubihsm auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ x509-cert = { version = "=0.3.0-pre.0", features = [ "builder", "hazmat" ] }
 
 [dependencies]
 bitflags = "2.5.0"
-der = "=0.8.0-rc.1"
+der = "=0.8.0-rc.2"
 des = "=0.9.0-pre.2"
 elliptic-curve = "=0.14.0-rc.1"
 hex = { package = "base16ct", version = "0.2", features = ["alloc"] }

--- a/src/apdu.rs
+++ b/src/apdu.rs
@@ -213,6 +213,21 @@ pub enum Ins {
     /// Management // DeviceReset
     DeviceReset,
 
+    /// YubiHSM Auth // Calculate session keys
+    Calculate,
+
+    /// YubiHSM Auth // Get challenge
+    GetHostChallenge,
+
+    /// YubiHSM Auth // List credentials
+    ListCredentials,
+
+    /// YubiHSM Auth // Put credential
+    PutCredential,
+
+    /// YubiHSM Auth // Delete credential
+    DeleteCredential,
+
     /// Other/unrecognized instruction codes
     Other(u8),
 }
@@ -244,6 +259,13 @@ impl Ins {
             Ins::WriteConfig => 0x1c,
             Ins::DeviceReset => 0x1f,
 
+            // Yubihsm auth
+            Ins::PutCredential => 0x01,
+            Ins::DeleteCredential => 0x02,
+            Ins::Calculate => 0x03,
+            Ins::GetHostChallenge => 0x04,
+            Ins::ListCredentials => 0x05,
+
             Ins::Other(code) => code,
         }
     }
@@ -257,6 +279,11 @@ impl From<u8> for Ins {
             0x1c => Ins::WriteConfig,
             0x1f => Ins::DeviceReset,
 
+            0x01 => Ins::PutCredential,
+            0x02 => Ins::DeleteCredential,
+            0x03 => Ins::Calculate,
+            0x04 => Ins::GetHostChallenge,
+            0x05 => Ins::ListCredentials,
             0x20 => Ins::Verify,
             0x24 => Ins::ChangeReference,
             0x2c => Ins::ResetRetry,

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -35,3 +35,13 @@ pub(crate) const TAG_UNLOCK: u8 = 0x0B;
 pub(crate) const TAG_REBOOT: u8 = 0x0C;
 pub(crate) const TAG_NFC_SUPPORTED: u8 = 0x0D;
 pub(crate) const TAG_NFC_ENABLED: u8 = 0x0E;
+
+// YubiHSM Auth
+pub(crate) const TAG_LABEL: u8 = 0x71;
+pub(crate) const TAG_PW: u8 = 0x73;
+pub(crate) const TAG_ALGO: u8 = 0x74;
+pub(crate) const TAG_KEY_ENC: u8 = 0x75;
+pub(crate) const TAG_KEY_MAC: u8 = 0x76;
+pub(crate) const TAG_CONTEXT: u8 = 0x77;
+pub(crate) const TAG_TOUCH: u8 = 0x7a;
+pub(crate) const TAG_MGMKEY: u8 = 0x7b;

--- a/src/hsmauth.rs
+++ b/src/hsmauth.rs
@@ -1,0 +1,324 @@
+//! YubiHSM Auth protocol
+//!
+//! YubiHSM Auth is a YubiKey CCID application that stores the long-lived
+//! credentials used to establish secure sessions with a YubiHSM 2. The secure
+//! session protocol is based on Secure Channel Protocol 3 (SCP03).
+use crate::{
+    error::{Error, Result},
+    transaction::Transaction,
+    YubiKey,
+};
+use nom::{
+    bytes::complete::{tag, take},
+    combinator::eof,
+    error::{Error as NumError, ErrorKind},
+    multi::many0,
+    number::complete::u8,
+    IResult,
+};
+use std::{fmt, str::FromStr};
+use zeroize::Zeroizing;
+
+/// Yubikey HSM Auth Applet ID
+pub(crate) const APPLET_ID: &[u8] = &[0xa0, 0x00, 0x00, 0x05, 0x27, 0x21, 0x07, 0x01];
+/// Yubikey HSM Auth Applet Name
+pub(crate) const APPLET_NAME: &str = "YubiHSM";
+
+/// AES key size in bytes. SCP03 theoretically supports other key sizes, but
+/// the YubiHSM 2 does not. Since this crate is somewhat specialized to the `YubiHSM 2` (at least for now)
+/// we hardcode to 128-bit for simplicity.
+pub(crate) const KEY_SIZE: usize = 16;
+
+/// Password to authenticate to the Yubikey HSM Auth Applet has a max length of 16
+pub(crate) const PW_LEN: usize = 16;
+
+/// Management key used to manipulate secrets (add/delete)
+pub struct MgmKey(pub [u8; PW_LEN]);
+
+impl Default for MgmKey {
+    fn default() -> Self {
+        // https://docs.yubico.com/yesdk/users-manual/application-yubihsm-auth/commands/change-management-key.html
+        // The default value of the management key is all zeros:
+        // 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+        Self([0; PW_LEN])
+    }
+}
+
+/// Label associated with a secret on the Yubikey.
+#[derive(Clone)]
+pub struct Label(pub(crate) Vec<u8>);
+
+impl Label {
+    const MAX_SIZE: usize = 64;
+}
+
+impl FromStr for Label {
+    type Err = Error;
+
+    fn from_str(input: &str) -> Result<Self> {
+        let buf = input.as_bytes();
+
+        if (1..=64).contains(&buf.len()) {
+            Ok(Self(buf.to_vec()))
+        } else {
+            Err(Error::ParseError)
+        }
+    }
+}
+
+/// [`Context`] holds the various challenges used for the authentication.
+///
+/// This is used as part of the key derivation for the session keys.
+pub struct Context(pub(crate) [u8; 16]);
+
+impl Context {
+    /// Creates a [`Context`] from its components
+    pub fn new(host_challenge: &Challenge, hsm_challenge: &Challenge) -> Self {
+        let mut out = Self::zeroed();
+        out.0[..8].copy_from_slice(host_challenge.as_slice());
+        out.0[8..].copy_from_slice(hsm_challenge.as_slice());
+
+        out
+    }
+
+    fn zeroed() -> Self {
+        Self([0u8; 16])
+    }
+
+    /// Build `Context` from the provided buffer
+    pub fn from_buf(buf: [u8; 16]) -> Self {
+        Self(buf)
+    }
+}
+
+/// Exclusive access to the Hsmauth applet.
+pub struct HsmAuth {
+    client: YubiKey,
+}
+
+impl HsmAuth {
+    pub(crate) fn new(mut client: YubiKey) -> Result<Self> {
+        Transaction::new(&mut client.card)?.select_application(
+            APPLET_ID,
+            APPLET_NAME,
+            "failed selecting YkHSM auth application",
+        )?;
+
+        Ok(Self { client })
+    }
+
+    /// Calculate session key with the specified key.
+    pub fn calculate(
+        &mut self,
+        label: Label,
+        context: Context,
+        password: &[u8],
+    ) -> Result<SessionKeys> {
+        Transaction::new(&mut self.client.card)?.calculate(
+            self.client.version,
+            label,
+            context,
+            password,
+        )
+    }
+
+    /// Get YubiKey Challenge
+    pub fn get_challenge(&mut self, label: Label) -> Result<Challenge> {
+        Transaction::new(&mut self.client.card)?.get_host_challenge(self.client.version, label)
+    }
+
+    /// List credentials
+    pub fn list_credentials(&mut self) -> Result<Vec<Credential>> {
+        Transaction::new(&mut self.client.card)?.list_credentials(self.client.version)
+    }
+
+    /// Put credential
+    pub fn put_credential(
+        &mut self,
+        mgmkey: Option<MgmKey>,
+        label: Label,
+        password: &[u8],
+        enc_key: [u8; KEY_SIZE],
+        mac_key: [u8; KEY_SIZE],
+        touch: bool,
+    ) -> Result<()> {
+        Transaction::new(&mut self.client.card)?.put_credential(
+            self.client.version,
+            mgmkey.unwrap_or_default(),
+            label,
+            password,
+            enc_key,
+            mac_key,
+            touch,
+        )
+    }
+
+    /// Delete credential
+    pub fn delete_credential(&mut self, mgmkey: Option<MgmKey>, label: Label) -> Result<()> {
+        Transaction::new(&mut self.client.card)?.delete_credential(
+            self.client.version,
+            mgmkey.unwrap_or_default(),
+            label,
+        )
+    }
+
+    /// Retun the inner `YubiKey`
+    pub fn into_inner(mut self) -> Result<YubiKey> {
+        Transaction::new(&mut self.client.card)?.select_piv_application()?;
+        Ok(self.client)
+    }
+}
+
+#[derive(Debug)]
+#[repr(u8)]
+/// Algorithm for the credentials
+pub enum Algorithm {
+    /// AES 128 keys
+    Aes128 = 38,
+    /// EC P256
+    EcP256 = 39,
+}
+
+impl fmt::Display for Algorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Algorithm::Aes128 => write!(f, "AES128"),
+            Algorithm::EcP256 => write!(f, "ECP256"),
+        }
+    }
+}
+
+impl Algorithm {
+    const SIZE: usize = 1;
+
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, value) = u8(input)?;
+        match value {
+            38 => Ok((input, Algorithm::Aes128)),
+            39 => Ok((input, Algorithm::EcP256)),
+            _ => Err(nom::Err::Error(NumError::new(input, ErrorKind::Tag))),
+        }
+    }
+}
+
+/// YubiHSM Auth credential store in the Application
+#[derive(Debug)]
+pub struct Credential {
+    /// Algorithm of the key
+    pub algorithm: Algorithm,
+    /// Is touch required when using this credential
+    pub touch: bool,
+    /// Remaining attempts to authenticate to this credential
+    pub remaining_attempts: u8,
+    /// Label for the credential
+    pub label: Vec<u8>,
+}
+
+impl Credential {
+    pub(crate) const SIZE: usize = 1 + /* tag prefix */
+        Algorithm::SIZE +
+        1 + /* touch */
+        1 + /* remaining_attempts */
+        Label::MAX_SIZE;
+
+    /// Parse a buffer holding a single credential
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, _list) = tag(b"\x72")(input)?;
+
+        let (input, buf_len) = u8(input)?;
+        let buf_len = if buf_len < 3 {
+            return Err(nom::Err::Error(NumError::new(
+                input,
+                ErrorKind::LengthValue,
+            )));
+        } else {
+            (buf_len - 3) as usize
+        };
+
+        let (input, algorithm) = Algorithm::parse(input)?;
+
+        let (input, touch) = u8(input)?;
+        let touch = match touch {
+            0 => false,
+            1 => true,
+            _ => return Err(nom::Err::Error(NumError::new(input, ErrorKind::Tag))),
+        };
+
+        let (input, label) = take(buf_len)(input)?;
+
+        let (input, remaining_attempts) = u8(input)?;
+
+        Ok((
+            input,
+            Credential {
+                algorithm,
+                touch,
+                label: label.to_vec(),
+                remaining_attempts,
+            },
+        ))
+    }
+
+    /// Parse a buffer holding a list of `Credential`
+    pub fn parse_list(input: &[u8]) -> Result<Vec<Self>> {
+        let (input, credentials) =
+            many0(Credential::parse)(input).map_err(|_| Error::ParseError)?;
+        let (_input, _) = eof(input).map_err(|_: nom::Err<NumError<&[u8]>>| Error::ParseError)?;
+
+        Ok(credentials)
+    }
+}
+
+/// The sessions keys after negociation via SCP03.
+#[derive(Default, Debug)]
+pub struct SessionKeys {
+    /// Session encryption key (S-ENC)
+    pub enc_key: Zeroizing<[u8; KEY_SIZE]>,
+    /// Session Command MAC key (S-MAC)
+    pub mac_key: Zeroizing<[u8; KEY_SIZE]>,
+    /// Session Respose MAC key (S-RMAC)
+    pub rmac_key: Zeroizing<[u8; KEY_SIZE]>,
+}
+
+/// Host challenge used for session keys calculation
+#[derive(Debug, Clone)]
+pub struct Challenge {
+    buffer: Zeroizing<[u8; Self::SIZE]>,
+    length: usize,
+}
+
+impl Challenge {
+    /// Challenge used in SCP03 computation
+    /// Can be as long as a P256 PUBKEY (for SCP11 support).
+    pub(crate) const SIZE: usize = 65;
+
+    /// Returns a slice containing the entire array.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buffer.as_slice()[..self.length]
+    }
+
+    /// Returns true if the challenge has a length of 0.
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+
+    /// Copy data from provided slice
+    pub fn copy_from_slice(&mut self, data: &[u8]) -> Result<()> {
+        self.length = data.len();
+        if self.length > Self::SIZE {
+            Err(Error::SizeError)
+        } else {
+            self.buffer[..self.length].copy_from_slice(data);
+            Ok(())
+        }
+    }
+}
+
+impl Default for Challenge {
+    fn default() -> Self {
+        Self {
+            buffer: Zeroizing::new([0u8; Self::SIZE]),
+            length: 0,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ mod chuid;
 mod config;
 mod consts;
 mod error;
+pub mod hsmauth;
 mod metadata;
 pub mod mgm;
 #[cfg(feature = "untested")]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     apdu::Response,
-    apdu::{Apdu, Ins, StatusWords},
+    apdu::{Apdu, Ins, NoLE, StatusWords, LE},
     consts::{
         CB_BUF_MAX, CB_OBJ_MAX, TAG_ALGO, TAG_CONTEXT, TAG_KEY_ENC, TAG_KEY_MAC, TAG_LABEL,
         TAG_MGMKEY, TAG_PW, TAG_TOUCH,
@@ -83,7 +83,7 @@ impl<'tx> Transaction<'tx> {
         let response = Apdu::new(Ins::SelectApplication)
             .p1(0x04)
             .data(applet)
-            .transmit(self, 0xFF)
+            .transmit::<NoLE>(self, 0xFF)
             .inspect_err(|e| error!("failed communicating with card: '{}'", e))?;
 
         if !response.is_success() {
@@ -100,7 +100,7 @@ impl<'tx> Transaction<'tx> {
     /// Get the version of the PIV application installed on the YubiKey.
     pub fn get_version(&self) -> Result<Version> {
         // get version from device
-        let response = Apdu::new(Ins::GetVersion).transmit(self, 261)?;
+        let response = Apdu::new(Ins::GetVersion).transmit::<NoLE>(self, 261)?;
 
         if !response.is_success() || response.data().is_empty() {
             return Err(Error::GenericError);
@@ -120,7 +120,7 @@ impl<'tx> Transaction<'tx> {
                     "failed selecting yk application",
                 )?;
 
-                let response = Apdu::new(0x01).p1(0x10).transmit(self, 0xFF)?;
+                let response = Apdu::new(0x01).p1(0x10).transmit::<NoLE>(self, 0xFF)?;
 
                 if !response.is_success() {
                     // TODO(tarcieri): still reselect the PIV applet in this case?
@@ -143,7 +143,7 @@ impl<'tx> Transaction<'tx> {
 
             // YK5 implements getting the serial as a PIV applet command (0xf8)
             5 => {
-                let response = Apdu::new(Ins::GetSerial).transmit(self, 0xFF)?;
+                let response = Apdu::new(Ins::GetSerial).transmit::<NoLE>(self, 0xFF)?;
 
                 if !response.is_success() {
                     error!(
@@ -165,7 +165,7 @@ impl<'tx> Transaction<'tx> {
     pub(crate) fn get_metadata(&self, slot: SlotId) -> Result<piv::SlotMetadata> {
         let response = Apdu::new(Ins::GetMetadata)
             .p2(slot.into())
-            .transmit(self, CB_OBJ_MAX)?;
+            .transmit::<NoLE>(self, CB_OBJ_MAX)?;
 
         if !response.is_success() {
             if response.status_words() == StatusWords::NotSupportedError {
@@ -198,7 +198,7 @@ impl<'tx> Transaction<'tx> {
             query.data(data.as_slice());
         }
 
-        let response = query.transmit(self, 261)?;
+        let response = query.transmit::<NoLE>(self, 261)?;
 
         match response.status_words() {
             StatusWords::Success => Ok(()),
@@ -409,7 +409,7 @@ impl<'tx> Transaction<'tx> {
                 .cla(cla)
                 .params(templ[2], templ[3])
                 .data(&in_data[in_offset..(in_offset + this_size)])
-                .transmit(self, 261)?;
+                .transmit::<NoLE>(self, 261)?;
 
             sw = response.status_words();
 
@@ -440,7 +440,7 @@ impl<'tx> Transaction<'tx> {
         while let StatusWords::BytesRemaining { len } = sw {
             trace!("The card indicates there is {} bytes more data for us", len);
 
-            let response = Apdu::new(Ins::GetResponseApdu).transmit(self, 261)?;
+            let response = Apdu::new(Ins::GetResponseApdu).transmit::<NoLE>(self, 261)?;
             sw = response.status_words();
 
             match sw {
@@ -614,7 +614,7 @@ impl<'tx> Transaction<'tx> {
         let response = Apdu::new(Ins::GetHostChallenge)
             .params(0x00, 0x00)
             .data(&data[..len])
-            .transmit(self, (Challenge::SIZE) + 2)?;
+            .transmit::<NoLE>(self, (Challenge::SIZE) + 2)?;
 
         // TODO: do we need to check response.data() is the size we asked?
         let data = response.data();
@@ -667,7 +667,7 @@ impl<'tx> Transaction<'tx> {
         let response = Apdu::new(Ins::Calculate)
             .params(0x00, 0x00)
             .data(&data[..len])
-            .transmit(self, (hsmauth::KEY_SIZE * 3) + 2)?;
+            .transmit::<NoLE>(self, (hsmauth::KEY_SIZE * 3) + 2)?;
 
         if !response.is_success() {
             error!(
@@ -718,7 +718,7 @@ impl<'tx> Transaction<'tx> {
         let response = Apdu::new(Ins::ListCredentials)
             .params(0x00, 0x00)
             .data(&data[..len])
-            .transmit(self, ((Credential::SIZE) * 32) + 2)?;
+            .transmit::<LE>(self, ((Credential::SIZE) * 32) + 2)?;
 
         let data = response.data();
         Credential::parse_list(data)
@@ -781,7 +781,7 @@ impl<'tx> Transaction<'tx> {
         let response = Apdu::new(Ins::PutCredential)
             .params(0x00, 0x00)
             .data(&data[..len])
-            .transmit(self, 2)?;
+            .transmit::<NoLE>(self, 2)?;
 
         if !response.is_success() {
             error!(
@@ -828,7 +828,7 @@ impl<'tx> Transaction<'tx> {
         let response = Apdu::new(Ins::DeleteCredential)
             .params(0x00, 0x00)
             .data(&data[..len])
-            .transmit(self, 2)?;
+            .transmit::<NoLE>(self, 2)?;
 
         if !response.is_success() {
             error!(

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -3,8 +3,12 @@
 use crate::{
     apdu::Response,
     apdu::{Apdu, Ins, StatusWords},
-    consts::{CB_BUF_MAX, CB_OBJ_MAX},
+    consts::{
+        CB_BUF_MAX, CB_OBJ_MAX, TAG_ALGO, TAG_CONTEXT, TAG_KEY_ENC, TAG_KEY_MAC, TAG_LABEL,
+        TAG_MGMKEY, TAG_PW, TAG_TOUCH,
+    },
     error::{Error, Result},
+    hsmauth::{self, Algorithm, Challenge, Context, Credential, Label, SessionKeys},
     otp,
     piv::{self, AlgorithmId, SlotId},
     serialization::*,
@@ -70,7 +74,7 @@ impl<'tx> Transaction<'tx> {
     }
 
     /// Select application.
-    pub fn select_application(
+    pub(crate) fn select_application(
         &self,
         applet: &[u8],
         applet_name: &'static str,
@@ -583,5 +587,257 @@ impl<'tx> Transaction<'tx> {
 
         let data = response.data();
         DeviceInfo::parse(data)
+    }
+
+    /// Get YubiKey Host challenge
+    pub fn get_host_challenge(&mut self, version: Version, label: Label) -> Result<Challenge> {
+        // YubiHSM was introduced by firmware 5.4.3
+        // https://docs.yubico.com/yesdk/users-manual/application-yubihsm-auth/yubihsm-auth-overview.html
+        if version
+            < (Version {
+                major: 5,
+                minor: 4,
+                patch: 3,
+            })
+        {
+            return Err(Error::NotSupported);
+        }
+
+        let mut data = [0u8; CB_BUF_MAX];
+        let mut len = data.len();
+        let mut data_remaining = &mut data[..];
+
+        let offset = Tlv::write(data_remaining, TAG_LABEL, &label.0)?;
+        data_remaining = &mut data_remaining[offset..];
+
+        len -= data_remaining.len();
+        let response = Apdu::new(Ins::GetHostChallenge)
+            .params(0x00, 0x00)
+            .data(&data[..len])
+            .transmit(self, (Challenge::SIZE) + 2)?;
+
+        // TODO: do we need to check response.data() is the size we asked?
+        let data = response.data();
+        let mut host_challenge = Challenge::default();
+
+        host_challenge.copy_from_slice(data)?;
+
+        Ok(host_challenge)
+    }
+
+    /// Get AES-128 session keys
+    ///
+    /// Get the SCP03 session keys from an AES-128 credential.
+    pub fn calculate(
+        &mut self,
+        version: Version,
+        label: Label,
+        context: Context,
+        password: &[u8],
+    ) -> Result<SessionKeys> {
+        // YubiHSM was introduced by firmware 5.4.3
+        // https://docs.yubico.com/yesdk/users-manual/application-yubihsm-auth/yubihsm-auth-overview.html
+        if version
+            < (Version {
+                major: 5,
+                minor: 4,
+                patch: 3,
+            })
+        {
+            return Err(Error::NotSupported);
+        }
+
+        let mut data = [0u8; CB_BUF_MAX];
+        let mut len = data.len();
+        let mut data_remaining = &mut data[..];
+
+        let offset = Tlv::write(data_remaining, TAG_LABEL, &label.0)?;
+        data_remaining = &mut data_remaining[offset..];
+
+        let offset = Tlv::write(data_remaining, TAG_CONTEXT, &context.0)?;
+        data_remaining = &mut data_remaining[offset..];
+
+        let mut password = password.to_vec();
+        password.resize(hsmauth::PW_LEN, 0);
+
+        let offset = Tlv::write(data_remaining, TAG_PW, &password)?;
+        data_remaining = &mut data_remaining[offset..];
+        len -= data_remaining.len();
+
+        let response = Apdu::new(Ins::Calculate)
+            .params(0x00, 0x00)
+            .data(&data[..len])
+            .transmit(self, (hsmauth::KEY_SIZE * 3) + 2)?;
+
+        if !response.is_success() {
+            error!(
+                "failed calculating the session secret: {:04x}",
+                response.status_words().code()
+            );
+            return Err(Error::GenericError);
+        }
+
+        let data = response.data();
+
+        // TODO: check length is long enough (KEY_SIZE*3)
+        let mut session_keys = SessionKeys::default();
+        session_keys
+            .enc_key
+            .copy_from_slice(&data[..hsmauth::KEY_SIZE]);
+        session_keys
+            .mac_key
+            .copy_from_slice(&data[hsmauth::KEY_SIZE..hsmauth::KEY_SIZE * 2]);
+        session_keys
+            .rmac_key
+            .copy_from_slice(&data[hsmauth::KEY_SIZE * 2..]);
+
+        Ok(session_keys)
+    }
+
+    /// Get AES-128 session keys
+    ///
+    /// Get the SCP03 session keys from an AES-128 credential.
+    pub fn list_credentials(&mut self, version: Version) -> Result<Vec<Credential>> {
+        // YubiHSM was introduced by firmware 5.4.3
+        // https://docs.yubico.com/yesdk/users-manual/application-yubihsm-auth/yubihsm-auth-overview.html
+        if version
+            < (Version {
+                major: 5,
+                minor: 4,
+                patch: 3,
+            })
+        {
+            return Err(Error::NotSupported);
+        }
+
+        let mut data = [0u8; CB_BUF_MAX];
+        let mut len = data.len();
+        let data_remaining = &mut data[..];
+
+        len -= data_remaining.len();
+        let response = Apdu::new(Ins::ListCredentials)
+            .params(0x00, 0x00)
+            .data(&data[..len])
+            .transmit(self, ((Credential::SIZE) * 32) + 2)?;
+
+        let data = response.data();
+        Credential::parse_list(data)
+    }
+
+    /// Adds a credential to YubiHSM Auth applet
+    #[allow(clippy::too_many_arguments)] // One argument over the limit of 7
+    pub fn put_credential(
+        &mut self,
+        version: Version,
+        mgmkey: hsmauth::MgmKey,
+        label: Label,
+        password: &[u8],
+        enc_key: [u8; hsmauth::KEY_SIZE],
+        mac_key: [u8; hsmauth::KEY_SIZE],
+        touch: bool,
+    ) -> Result<()> {
+        // YubiHSM was introduced by firmware 5.4.3
+        // https://docs.yubico.com/yesdk/users-manual/application-yubihsm-auth/yubihsm-auth-overview.html
+        if version
+            < (Version {
+                major: 5,
+                minor: 4,
+                patch: 3,
+            })
+        {
+            return Err(Error::NotSupported);
+        }
+
+        let mut data = [0u8; CB_BUF_MAX];
+        let mut len = data.len();
+        let mut data_remaining = &mut data[..];
+
+        let offset = Tlv::write(data_remaining, TAG_MGMKEY, &mgmkey.0)?;
+        data_remaining = &mut data_remaining[offset..];
+
+        let offset = Tlv::write(data_remaining, TAG_LABEL, &label.0)?;
+        data_remaining = &mut data_remaining[offset..];
+
+        let offset = Tlv::write(data_remaining, TAG_ALGO, &[Algorithm::Aes128 as u8])?;
+        data_remaining = &mut data_remaining[offset..];
+
+        let offset = Tlv::write(data_remaining, TAG_KEY_ENC, &enc_key)?;
+        data_remaining = &mut data_remaining[offset..];
+
+        let offset = Tlv::write(data_remaining, TAG_KEY_MAC, &mac_key)?;
+        data_remaining = &mut data_remaining[offset..];
+
+        let mut password = password.to_vec();
+        password.resize(hsmauth::PW_LEN, 0);
+
+        let offset = Tlv::write(data_remaining, TAG_PW, &password)?;
+        data_remaining = &mut data_remaining[offset..];
+
+        let offset = Tlv::write(data_remaining, TAG_TOUCH, &[touch as u8])?;
+        data_remaining = &mut data_remaining[offset..];
+
+        len -= data_remaining.len();
+
+        let response = Apdu::new(Ins::PutCredential)
+            .params(0x00, 0x00)
+            .data(&data[..len])
+            .transmit(self, 2)?;
+
+        if !response.is_success() {
+            error!(
+                "Unable to store credential: {:04x}",
+                response.status_words().code()
+            );
+            return Err(Error::GenericError);
+        }
+
+        Ok(())
+    }
+
+    /// Delete a credential to YubiHSM Auth applet
+    pub fn delete_credential(
+        &mut self,
+        version: Version,
+        mgmkey: hsmauth::MgmKey,
+        label: Label,
+    ) -> Result<()> {
+        // YubiHSM was introduced by firmware 5.4.3
+        // https://docs.yubico.com/yesdk/users-manual/application-yubihsm-auth/yubihsm-auth-overview.html
+        if version
+            < (Version {
+                major: 5,
+                minor: 4,
+                patch: 3,
+            })
+        {
+            return Err(Error::NotSupported);
+        }
+
+        let mut data = [0u8; CB_BUF_MAX];
+        let mut len = data.len();
+        let mut data_remaining = &mut data[..];
+
+        let offset = Tlv::write(data_remaining, TAG_MGMKEY, &mgmkey.0)?;
+        data_remaining = &mut data_remaining[offset..];
+
+        let offset = Tlv::write(data_remaining, TAG_LABEL, &label.0)?;
+        data_remaining = &mut data_remaining[offset..];
+
+        len -= data_remaining.len();
+
+        let response = Apdu::new(Ins::DeleteCredential)
+            .params(0x00, 0x00)
+            .data(&data[..len])
+            .transmit(self, 2)?;
+
+        if !response.is_success() {
+            error!(
+                "Unable to delete credential: {:04x}",
+                response.status_words().code()
+            );
+            return Err(Error::GenericError);
+        }
+
+        Ok(())
     }
 }

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -36,6 +36,7 @@ use crate::{
     chuid::ChuId,
     config::Config,
     error::{Error, Result},
+    hsmauth::HsmAuth,
     mgm::MgmKey,
     piv,
     reader::{Context, Reader},
@@ -743,6 +744,11 @@ impl YubiKey {
         }
 
         Ok(())
+    }
+
+    /// Creates a client for the YubiHSM AUth
+    pub fn hsmauth(self) -> Result<HsmAuth> {
+        HsmAuth::new(self)
     }
 }
 

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -31,7 +31,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    apdu::{Apdu, Ins},
+    apdu::{Apdu, Ins, NoLE},
     cccid::CccId,
     chuid::ChuId,
     config::Config,
@@ -418,7 +418,7 @@ impl YubiKey {
         let challenge = Apdu::new(Ins::Authenticate)
             .params(ALGO_3DES, KEY_CARDMGM)
             .data([TAG_DYN_AUTH, 0x02, 0x80, 0x00])
-            .transmit(&txn, 261)?;
+            .transmit::<NoLE>(&txn, 261)?;
 
         if !challenge.is_success() || challenge.data().len() < 12 {
             return Err(Error::AuthenticationError);
@@ -443,7 +443,7 @@ impl YubiKey {
         let authentication = Apdu::new(Ins::Authenticate)
             .params(ALGO_3DES, KEY_CARDMGM)
             .data(data)
-            .transmit(&txn, 261)?;
+            .transmit::<NoLE>(&txn, 261)?;
 
         if !authentication.is_success() {
             return Err(Error::AuthenticationError);


### PR DESCRIPTION
This is used to calculate session keys for Yubico HSM.

TODO:
 - [x] Test against an HSM the generated keys match
 - [x] Add helpers for:
   - [x] adding
   - [x] deleting 
   - [x] listing credentials