### PR TITLE
Make YubiKey::open() more robust

### DIFF
--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -178,7 +178,7 @@ impl fmt::Debug for YubiKey {
 impl YubiKey {
     /// Open a connection to a YubiKey.
     ///
-    /// Returns an error if there is more than one YubiKey detected.
+    /// Returns an error if more than one YubiKey is detected (or none at all).
     ///
     /// NOTE: If multiple YubiKeys are connected, but we are only able to
     /// open one of them (e.g. because the other one is in use, and the


### PR DESCRIPTION
My Notebook contains a physical smart card reader, which caused the `YubiKey::open()` function to falsely claim that multiple YubiKey are connected (because two `Reader`s exist: one of them being the empty physical reader, the other being an actual YubiKey).

This patch fixes that. I think the change is preferable to the previous code (and it fixes `open()` on my machine).
However, there is one possible downside (also described in the doc comment):

If two YubiKeys are connected, and one is currently opened (and locked as exclusive), the caller will now receive "the other" YubiKey, with the (somewhat misleading) implication that only one YubiKey is connected to the system. There is no indication that multiple YubiKey are connected, and I can't imagine a reliable way to avoid such a scenario (if there's a card we can't open, I think we also can't find out what kind of card it is).

I assume the new semantics are acceptable (preferable) in most cases. But it might theoretically trip up users who relied on the previous semantics (which I assume happened to work as expected, as long as no non-YubiKey `Reader`s are connected).