### PR TITLE
Add a feature flag that controls PIN caching.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
 pcsc = "2.3.1"
 rand_core = { version = "0.6", features = ["std"] }
 rsa = "0.9"
-secrecy = "0.8"
+secrecy = { version = "0.8", optional = true }
 sha1 = { version = "0.10", features = ["oid"] }
 sha2 = { version = "0.10", features = ["oid"] }
 subtle = "2"
@@ -53,7 +53,9 @@ once_cell = "1"
 signature = "2"
 
 [features]
+default = ["cache-pin"]
 untested = []
+cache-pin = ["secrecy"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,11 @@ pub use crate::{
     policy::{PinPolicy, TouchPolicy},
     reader::Context,
     setting::{Setting, SettingSource},
-    yubikey::{CachedPin, Serial, Version, YubiKey},
+    yubikey::{Serial, Version, YubiKey},
 };
+
+#[cfg(feature = "cache-pin")]
+pub use crate::yubikey::CachedPin;
 
 #[cfg(feature = "untested")]
 pub use crate::{mscmap::MsContainer, msroots::MsRoots};


### PR DESCRIPTION
While SecretVec prevents accidentally logging or printing the PIN, caching the PIN in RAM in a long-running application would presumably allow it to be read from memory, or even from disk if the program gets swapped out.

This commit adds a feature (enabled by default) that controls PIN caching. If the `cache-pin` feature is disabled, the PIN is not cached in memory and some YubiKey methods become unavailable.