### PR TITLE
add length check to get_version

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -92,7 +92,7 @@ impl<'tx> Transaction<'tx> {
         // get version from device
         let response = Apdu::new(Ins::GetVersion).transmit(self, 261)?;
 
-        if !response.is_success() {
+        if !response.is_success() || 0 == response.data().len() {
             return Err(Error::GenericError);
         }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -92,7 +92,7 @@ impl<'tx> Transaction<'tx> {
         // get version from device
         let response = Apdu::new(Ins::GetVersion).transmit(self, 261)?;
 
-        if !response.is_success() || 0 == response.data().len() {
+        if !response.is_success() || response.data().is_empty() {
             return Err(Error::GenericError);
         }
 


### PR DESCRIPTION
This check was added after observing middleware returning 0 length data here.