### PR TITLE
Handle reference data not found in metadata command

### DIFF
--- a/src/apdu.rs
+++ b/src/apdu.rs
@@ -395,6 +395,9 @@ pub(crate) enum StatusWords {
     /// Not enough memory
     NoSpaceError,
 
+    /// Referenced data or reference data not found
+    ReferenceDataNotFoundError,
+
     //
     // Custom Yubico Status Word extensions
     //
@@ -428,6 +431,7 @@ impl StatusWords {
             StatusWords::IncorrectParamError => 0x6a80,
             StatusWords::NotFoundError => 0x6a82,
             StatusWords::NoSpaceError => 0x6a84,
+            StatusWords::ReferenceDataNotFoundError => 0x6a88,
             StatusWords::IncorrectSlotError => 0x6b00,
             StatusWords::NotSupportedError => 0x6d00,
             StatusWords::CommandAbortedError => 0x6f00,
@@ -462,6 +466,7 @@ impl From<u16> for StatusWords {
             0x6a80 => StatusWords::IncorrectParamError,
             0x6a82 => StatusWords::NotFoundError,
             0x6a84 => StatusWords::NoSpaceError,
+            0x6a88 => StatusWords::ReferenceDataNotFoundError,
             0x6b00 => StatusWords::IncorrectSlotError,
             0x6d00 => StatusWords::NotSupportedError,
             0x6f00 => StatusWords::CommandAbortedError,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -315,6 +315,52 @@ fn test_read_metadata() {
 
 #[test]
 #[ignore]
+fn test_read_metadata_missing_key() {
+    let mut yubikey = YUBIKEY.lock().unwrap();
+
+    assert!(yubikey.verify_pin(b"123456").is_ok());
+    assert!(yubikey.authenticate(MgmKey::default()).is_ok());
+
+    // we assume that at least one of these slots is empty
+    let slots_to_check = [
+        RetiredSlotId::R10,
+        RetiredSlotId::R11,
+        RetiredSlotId::R12,
+        RetiredSlotId::R13,
+        RetiredSlotId::R14,
+        RetiredSlotId::R15,
+        RetiredSlotId::R16,
+        RetiredSlotId::R17,
+        RetiredSlotId::R18,
+        RetiredSlotId::R19,
+        RetiredSlotId::R20,
+    ];
+
+    for slot in slots_to_check {
+        let slot = SlotId::Retired(slot);
+
+        match piv::metadata(&mut yubikey, slot) {
+            Ok(_) => {
+                eprintln!("Key {} exists", slot);
+            }
+            Err(Error::NotSupported) => {
+                // Some YubiKeys don't support metadata
+                eprintln!("metadata not supported by this YubiKey");
+                return;
+            }
+            Err(Error::NotFound) => {
+                eprintln!("Key {} doesn't exist, ok.", slot);
+                return;
+            }
+            Err(err) => panic!("{}", err),
+        }
+    }
+
+    panic!("No empty slots to check");
+}
+
+#[test]
+#[ignore]
 fn test_parse_cert_from_der() {
     let bob_der = std::fs::read("tests/assets/Bob.der").expect(".der file not found");
     let cert =


### PR DESCRIPTION
This PR adds handling of the reference data not found in the metadata command which is returned when an object doesn't exist. We treat it as `Error::NotFound`. I tried to add a small test for it, though it may be a bit _flaky_.

Also, when I tried other commands on an empty slot ('sign' and 'attest'), they returned an "invalid param" error rather than "not found" or something similar, so I believe we can't handle this case with those commands.

Fixes #557.