### PR TITLE
Add curve 25519 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -56,7 +56,7 @@ checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -172,7 +172,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -214,9 +214,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -244,6 +244,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,7 +294,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -284,7 +311,7 @@ checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -347,7 +374,7 @@ checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -360,6 +387,30 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -426,6 +477,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "generic-array"
@@ -580,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -831,7 +888,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -848,18 +905,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -942,6 +999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,10 +1060,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
 name = "serde"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
 
 [[package]]
 name = "sha1"
@@ -1077,6 +1163,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,7 +1181,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "unicode-xid",
 ]
 
@@ -1114,7 +1211,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1227,7 +1324,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -1249,7 +1346,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1349,6 +1446,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,8 +1492,10 @@ dependencies = [
  "base16ct",
  "chrono",
  "cookie-factory",
+ "curve25519-dalek",
  "der-parser",
  "des",
+ "ed25519-dalek",
  "elliptic-curve",
  "env_logger",
  "hmac",
@@ -1406,6 +1517,7 @@ dependencies = [
  "signature",
  "subtle",
  "uuid",
+ "x25519-dalek",
  "x509",
  "x509-parser",
  "zeroize",
@@ -1431,3 +1543,17 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ p256 = "0.13"
 p384 = "0.13"
 curve25519-dalek = "4"
 x25519-dalek = "2"
-ed25519-dalek = {version = "2", features = ["pkcs8"]}
+ed25519-dalek = "2"
 pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
 pcsc = "2.3.1"
 rand_core = { version = "0.6", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ p256 = "0.13"
 p384 = "0.13"
 curve25519-dalek = "4"
 x25519-dalek = "2"
-ed25519-dalek = "2"
+ed25519-dalek = {version = "2", features = ["pkcs8"]}
 pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
 pcsc = "2.3.1"
 rand_core = { version = "0.6", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ num-traits = "0.2"
 num-integer = "0.1"
 p256 = "0.13"
 p384 = "0.13"
+curve25519-dalek = "4"
+x25519-dalek = "2"
+ed25519-dalek = "2"
 pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
 pcsc = "2.3.1"
 rand_core = { version = "0.6", features = ["std"] }

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -207,23 +207,11 @@ pub enum PublicKeyInfo {
     /// EC P-384 keys
     EcP384(EcPublicKey<NistP384>),
 
-    /// ED25519 Keys
-    Ed25519 {
-        /// ED25519 Algorithm
-        algorithm: AlgorithmId,
+    /// ED25519 keys
+    Ed25519(CvSigningKey),
 
-        /// Public key
-        pubkey: CvSigningKey,
-    },
-
-    /// X25519 Keys
-    X25519 {
-        /// X25519 Algorithm
-        algorithm: AlgorithmId,
-
-        /// Public key
-        pubkey: CvPublicKey,
-    },
+    /// X25519 keys
+    X25519(CvPublicKey),
 }
 
 impl fmt::Debug for PublicKeyInfo {
@@ -278,10 +266,9 @@ impl PublicKeyInfo {
                     .as_ref()
                     .ok_or(Error::InvalidObject)?;
                 match read_pki::cv_parameters(algorithm_parameters)? {
-                    AlgorithmId::Ed25519 => Ok(PublicKeyInfo::Ed25519 {
-                        algorithm: AlgorithmId::Ed25519,
-                        pubkey: CvSigningKey::from(key_bytes),
-                    }),
+                    AlgorithmId::Ed25519 => {
+                        Ok(PublicKeyInfo::Ed25519(CvSigningKey::from(key_bytes)))
+                    }
                     _ => Err(Error::AlgorithmError),
                 }
             }
@@ -298,10 +285,7 @@ impl PublicKeyInfo {
                     .as_ref()
                     .ok_or(Error::InvalidObject)?;
                 match read_pki::cv_parameters(algorithm_parameters)? {
-                    AlgorithmId::X25519 => Ok(PublicKeyInfo::X25519 {
-                        algorithm: AlgorithmId::X25519,
-                        pubkey: CvPublicKey::from(key_bytes),
-                    }),
+                    AlgorithmId::X25519 => Ok(PublicKeyInfo::X25519(CvPublicKey::from(key_bytes))),
                     _ => Err(Error::AlgorithmError),
                 }
             }
@@ -315,8 +299,8 @@ impl PublicKeyInfo {
             PublicKeyInfo::Rsa { algorithm, .. } => *algorithm,
             PublicKeyInfo::EcP256(_) => AlgorithmId::EccP256,
             PublicKeyInfo::EcP384(_) => AlgorithmId::EccP384,
-            PublicKeyInfo::Ed25519 { algorithm, .. } => *algorithm,
-            PublicKeyInfo::X25519 { algorithm, .. } => *algorithm,
+            PublicKeyInfo::Ed25519(_) => AlgorithmId::Ed25519,
+            PublicKeyInfo::X25519(_) => AlgorithmId::X25519,
         }
     }
 }
@@ -337,8 +321,8 @@ impl x509::SubjectPublicKeyInfo for PublicKeyInfo {
             }
             PublicKeyInfo::EcP256(pubkey) => pubkey.as_bytes().to_vec(),
             PublicKeyInfo::EcP384(pubkey) => pubkey.as_bytes().to_vec(),
-            PublicKeyInfo::Ed25519 { pubkey, .. } => pubkey.to_bytes().to_vec(),
-            PublicKeyInfo::X25519 { pubkey, .. } => pubkey.to_bytes().to_vec(),
+            PublicKeyInfo::Ed25519(pubkey) => pubkey.to_bytes().to_vec(),
+            PublicKeyInfo::X25519(pubkey) => pubkey.to_bytes().to_vec(),
         }
     }
 }

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -40,7 +40,7 @@ use crate::{
     Buffer,
 };
 use chrono::{DateTime, Utc};
-use ed25519_dalek::{SecretKey as CvSecretKey, SigningKey as CvSigningKey};
+use ed25519_dalek::SigningKey as CvSigningKey;
 use elliptic_curve::sec1::EncodedPoint as EcPublicKey;
 use log::error;
 use num_bigint_dig::BigUint;
@@ -266,7 +266,7 @@ impl PublicKeyInfo {
                 }
             }
             OID_ED25519 => {
-                let key_bytes: CvSecretKey = subject_pki
+                let key_bytes: [u8; 32] = subject_pki
                     .subject_public_key
                     .data
                     .to_vec()
@@ -286,7 +286,7 @@ impl PublicKeyInfo {
                 }
             }
             OID_X25519 => {
-                let key_bytes: CvSecretKey = subject_pki
+                let key_bytes: [u8; 32] = subject_pki
                     .subject_public_key
                     .data
                     .to_vec()

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -256,38 +256,20 @@ impl PublicKeyInfo {
             OID_ED25519 => {
                 let key_bytes: [u8; 32] = subject_pki
                     .subject_public_key
-                    .data
-                    .to_vec()
+                    .as_ref()
                     .try_into()
                     .map_err(|_| Error::InvalidObject)?;
-                let algorithm_parameters = subject_pki
-                    .algorithm
-                    .parameters
-                    .as_ref()
-                    .ok_or(Error::InvalidObject)?;
-                match read_pki::cv_parameters(algorithm_parameters)? {
-                    AlgorithmId::Ed25519 => Ok(PublicKeyInfo::Ed25519(
-                        CvVerifyingKey::from_bytes(&key_bytes).map_err(|_| Error::InvalidObject)?,
-                    )),
-                    _ => Err(Error::AlgorithmError),
-                }
+                Ok(PublicKeyInfo::Ed25519(
+                    CvVerifyingKey::from_bytes(&key_bytes).map_err(|_| Error::InvalidObject)?,
+                ))
             }
             OID_X25519 => {
                 let key_bytes: [u8; 32] = subject_pki
                     .subject_public_key
-                    .data
-                    .to_vec()
+                    .as_ref()
                     .try_into()
                     .map_err(|_| Error::InvalidObject)?;
-                let algorithm_parameters = subject_pki
-                    .algorithm
-                    .parameters
-                    .as_ref()
-                    .ok_or(Error::InvalidObject)?;
-                match read_pki::cv_parameters(algorithm_parameters)? {
-                    AlgorithmId::X25519 => Ok(PublicKeyInfo::X25519(CvPublicKey::from(key_bytes))),
-                    _ => Err(Error::AlgorithmError),
-                }
+                Ok(PublicKeyInfo::X25519(CvPublicKey::from(key_bytes)))
             }
             _ => Err(Error::InvalidObject),
         }

--- a/src/piv.rs
+++ b/src/piv.rs
@@ -1168,14 +1168,8 @@ fn read_public_key(
             let pk_data: [u8; 32] = tlv.value.try_into().map_err(|_| Error::InvalidObject)?;
 
             match algorithm {
-                AlgorithmId::Ed25519 => Ok(PublicKeyInfo::Ed25519 {
-                    algorithm: AlgorithmId::Ed25519,
-                    pubkey: CvSigningKey::from(pk_data),
-                }),
-                AlgorithmId::X25519 => Ok(PublicKeyInfo::X25519 {
-                    algorithm: AlgorithmId::X25519,
-                    pubkey: CvPublicKey::from(pk_data),
-                }),
+                AlgorithmId::Ed25519 => Ok(PublicKeyInfo::Ed25519(CvSigningKey::from(pk_data))),
+                AlgorithmId::X25519 => Ok(PublicKeyInfo::X25519(CvPublicKey::from(pk_data))),
                 _ => return Err(Error::AlgorithmError),
             }
         }

--- a/src/piv.rs
+++ b/src/piv.rs
@@ -53,7 +53,7 @@ use crate::{
     yubikey::YubiKey,
     Buffer, ObjectId,
 };
-use ed25519_dalek::SigningKey as CvSigningKey;
+use ed25519_dalek::VerifyingKey as CvVerifyingKey;
 use elliptic_curve::sec1::EncodedPoint as EcPublicKey;
 use log::{debug, error, warn};
 use p256::NistP256;
@@ -1168,7 +1168,9 @@ fn read_public_key(
             let pk_data: [u8; 32] = tlv.value.try_into().map_err(|_| Error::InvalidObject)?;
 
             match algorithm {
-                AlgorithmId::Ed25519 => Ok(PublicKeyInfo::Ed25519(CvSigningKey::from(pk_data))),
+                AlgorithmId::Ed25519 => CvVerifyingKey::from_bytes(&pk_data)
+                    .map(PublicKeyInfo::Ed25519)
+                    .map_err(|_| Error::InvalidObject),
                 AlgorithmId::X25519 => Ok(PublicKeyInfo::X25519(CvPublicKey::from(pk_data))),
                 _ => return Err(Error::AlgorithmError),
             }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -340,7 +340,9 @@ impl<'tx> Transaction<'tx> {
                 Tlv::write(
                     &mut buf[2..],
                     match (algorithm, decipher) {
-                        (AlgorithmId::EccP256, true) | (AlgorithmId::EccP384, true) => 0x85,
+                        (AlgorithmId::EccP256, true)
+                        | (AlgorithmId::EccP384, true)
+                        | (AlgorithmId::X25519, true) => 0x85,
                         _ => 0x81,
                     },
                     sign_in

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -311,6 +311,19 @@ impl<'tx> Transaction<'tx> {
                     return Err(Error::SizeError);
                 }
             }
+            AlgorithmId::X25519 => {
+                if !decipher {
+                    return Err(Error::NotSupported);
+                }
+                if in_len != 32 {
+                    return Err(Error::SizeError);
+                }
+            }
+            AlgorithmId::Ed25519 => {
+                if decipher {
+                    return Err(Error::NotSupported);
+                }
+            }
         }
 
         let bytes = if in_len < 0x80 {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -274,15 +274,13 @@ fn generate_self_signed_cv_cert() {
     let cert_len = data[2] as usize;
     let tbs_cert_len = data[5] as usize;
     let sig_algo_len: usize = 64;
-    let sig_start = cert_len - sig_algo_len;
-    // FIXME: Not sure what the msg should be for Ed25519 signed x509 cert
-    let msg = &data[6..9 + tbs_cert_len];
+    let sig_start = cert_len - sig_algo_len + 3;
+    let msg = &data[3..6 + tbs_cert_len];
     let sig =
         ed25519_dalek::Signature::from_slice(&data[sig_start..sig_start + sig_algo_len]).unwrap();
-    let vk = ed25519_dalek::VerifyingKey::from(pubkey);
 
     use ed25519_dalek::Verifier;
-    assert!(vk.verify(msg, &sig).is_ok());
+    assert!(pubkey.verify(msg, &sig).is_ok());
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -266,7 +266,7 @@ fn generate_self_signed_cv_cert() {
     //
 
     let pubkey = match cert.subject_pki() {
-        PublicKeyInfo::Ed25519 { pubkey, .. } => pubkey,
+        PublicKeyInfo::Ed25519(pubkey) => pubkey,
         _ => unreachable!(),
     };
 


### PR DESCRIPTION
Yubico added support for curve 25519 in the PIV applet since firmware '5.7.X'. This support has already been added to [yubico-piv-tool](https://github.com/Yubico/yubico-piv-tool), but it is lacking in this Rust library. This PR is an attempt to keep the libraries aligned on functionality. Changes made are as described:
* `curve25519-dalek` crates added as dependencies
* `X25519` and `Ed25519` added as available algorithms
* Updated the integration tests to include an ED25519 signature check
  - Tests did not seem to work well for me (constant poisoned mutex issue) so I made some modifications but can revert these if necessary
  - Wise to double check these work as intended

I'm open to any feedback. This is my first real go at production Rust code so criticism is welcome/needed for me to learn.

Additional items to maybe consider:
* I'm not sure how this will impact anyone using firmware older than '5.7.X'
  - Might want to add a check on that and throw `NotSupported` errors
  - Otherwise, take an approach where firmware version is tied to release version?