### PR TITLE
PIV: Add AES keys for MGM management keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "zeroize",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -1050,7 +1063,10 @@ dependencies = [
 name = "yubikey"
 version = "0.8.0"
 dependencies = [
+ "aes",
  "base16ct",
+ "cipher",
+ "crypto-common",
  "der",
  "des",
  "ecdsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ x509-cert = { version = "0.2.5", features = [ "builder", "hazmat" ] }
 [dependencies]
 der = "0.7.1"
 des = "0.8"
+aes = { version = "0.8.4", features = ["zeroize"] }
 elliptic-curve = "0.13"
 hex = { package = "base16ct", version = "0.2", features = ["alloc"] }
 hmac = "0.12"
@@ -48,6 +49,8 @@ subtle = "2"
 uuid = { version = "1.2", features = ["v4"] }
 x509-cert.workspace = true
 zeroize = "1"
+cipher = "0.4.4"
+crypto-common = { version = "0.1.6", features = ["rand_core"] }
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/src/error.rs
+++ b/src/error.rs
@@ -192,8 +192,8 @@ impl std::error::Error for Error {
     }
 }
 
-impl From<x509_cert::der::Error> for Error {
-    fn from(_err: x509_cert::der::Error) -> Error {
+impl From<der::Error> for Error {
+    fn from(_err: der::Error) -> Error {
         Error::ParseError
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub use crate::{
     chuid::ChuId,
     config::Config,
     error::{Error, Result},
-    mgm::{MgmKey, MgmType, MgmKeyAlgorithm, MgmKey3Des, MgmKeyAes128, MgmKeyAes192, MgmKeyAes256},
+    mgm::{MgmKey, MgmKey3Des, MgmKeyAes128, MgmKeyAes192, MgmKeyAes256, MgmKeyAlgorithm, MgmType},
     piv::Key,
     policy::{PinPolicy, TouchPolicy},
     reader::Context,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub use crate::{
     chuid::ChuId,
     config::Config,
     error::{Error, Result},
-    mgm::{MgmKey, MgmType},
+    mgm::{MgmKey, MgmType, MgmKeyAlgorithm, MgmKey3Des, MgmKeyAes128, MgmKeyAes192, MgmKeyAes256},
     piv::Key,
     policy::{PinPolicy, TouchPolicy},
     reader::Context,

--- a/src/mgm.rs
+++ b/src/mgm.rs
@@ -92,7 +92,7 @@ pub enum MgmType {
 
 /// The algorithm used for the MGM key.
 pub trait MgmKeyAlgorithm:
-    BlockCipher + BlockDecrypt + BlockEncrypt + KeyInit + private::Seal
+    BlockCipher + BlockDecrypt + BlockEncrypt + Clone + KeyInit + private::Seal
 {
     /// The KeySized used for this algorithm
     const KEY_SIZE: u8;
@@ -172,7 +172,7 @@ impl MgmKeyAlgorithm for des::TdesEee3 {
                     &key_bytes
                 );
 
-                return Err(Error::KeyError)
+                return Err(Error::KeyError);
             }
         }
 
@@ -459,8 +459,7 @@ impl<C: MgmKeyAlgorithm> MgmKey<C> {
 
         let mut output = challenge.to_owned();
 
-        C::new(&self.key)
-            .decrypt_block(GenericArray::from_mut_slice(&mut output));
+        C::new(&self.key).decrypt_block(GenericArray::from_mut_slice(&mut output));
 
         Ok(output)
     }
@@ -473,8 +472,7 @@ impl<C: MgmKeyAlgorithm> MgmKey<C> {
             return Err(Error::AuthenticationError);
         }
 
-        C::new(&self.key)
-            .encrypt_block(GenericArray::from_mut_slice(&mut response));
+        C::new(&self.key).encrypt_block(GenericArray::from_mut_slice(&mut response));
 
         use subtle::ConstantTimeEq;
         if response.ct_eq(auth_data).unwrap_u8() != 1 {

--- a/src/mgm.rs
+++ b/src/mgm.rs
@@ -108,7 +108,7 @@ pub trait MgmKeyAlgorithm:
     }
 }
 
-impl MgmKeyAlgorithm for des::TdesEee3 {
+impl MgmKeyAlgorithm for des::TdesEde3 {
     const KEY_SIZE: u8 = 24;
     const ALGORITHM_ID: u8 = 0x03;
 
@@ -208,7 +208,7 @@ pub struct MgmKey<C: MgmKeyAlgorithm> {
 }
 
 /// A Management Key (MGM) using Triple-DES
-pub type MgmKey3Des = MgmKey<des::TdesEee3>;
+pub type MgmKey3Des = MgmKey<des::TdesEde3>;
 
 /// A Management Key (MGM) using AES-128
 pub type MgmKeyAes128 = MgmKey<aes::Aes128>;
@@ -522,7 +522,7 @@ impl<'a, C: MgmKeyAlgorithm> TryFrom<&'a [u8]> for MgmKey<C> {
 // Seal the MgmKeyAlgorithm trait
 mod private {
     pub trait Seal {}
-    impl Seal for des::TdesEee3 {}
+    impl Seal for des::TdesEde3 {}
     impl Seal for aes::Aes128 {}
     impl Seal for aes::Aes192 {}
     impl Seal for aes::Aes256 {}

--- a/src/piv.rs
+++ b/src/piv.rs
@@ -1218,8 +1218,14 @@ fn read_public_key(
 pub enum ManagementAlgorithmId {
     /// Used on PIN and PUK slots.
     PinPuk,
-    /// Used on the key management slot.
+    /// Used on the key management slot to indicate the management key is TripleDes.
     ThreeDes,
+    /// Used on the key management slot to indicate the management key is AES-128.
+    Aes128,
+    /// Used on the key management slot to indicate the management key is AES-192.
+    Aes192,
+    /// Used on the key management slot to indicate the management key is AES-256.
+    Aes256,
     /// Used on all other slots.
     Asymmetric(AlgorithmId),
 }
@@ -1231,6 +1237,9 @@ impl TryFrom<u8> for ManagementAlgorithmId {
         match value {
             0xff => Ok(ManagementAlgorithmId::PinPuk),
             0x03 => Ok(ManagementAlgorithmId::ThreeDes),
+            0x08 => Ok(ManagementAlgorithmId::Aes128),
+            0x0a => Ok(ManagementAlgorithmId::Aes192),
+            0x0c => Ok(ManagementAlgorithmId::Aes256),
             oth => AlgorithmId::try_from(oth).map(ManagementAlgorithmId::Asymmetric),
         }
     }
@@ -1241,6 +1250,9 @@ impl From<ManagementAlgorithmId> for u8 {
         match id {
             ManagementAlgorithmId::PinPuk => 0xff,
             ManagementAlgorithmId::ThreeDes => 0x03,
+            ManagementAlgorithmId::Aes128 => 0x08,
+            ManagementAlgorithmId::Aes192 => 0x0a,
+            ManagementAlgorithmId::Aes256 => 0x0c,
             ManagementAlgorithmId::Asymmetric(oth) => oth.into(),
         }
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -244,7 +244,11 @@ impl<'tx> Transaction<'tx> {
 
     /// Set the management key (MGM).
     #[cfg(feature = "untested")]
-    pub fn set_mgm_key<C: MgmKeyAlgorithm>(&self, new_key: &MgmKey<C>, require_touch: bool) -> Result<()> {
+    pub fn set_mgm_key<C: MgmKeyAlgorithm>(
+        &self,
+        new_key: &MgmKey<C>,
+        require_touch: bool,
+    ) -> Result<()> {
         let p2 = if require_touch { 0xfe } else { 0xff };
 
         let mut data = Vec::with_capacity(new_key.key_size() as usize + 3);

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -195,8 +195,8 @@ impl YubiKey {
                 if let Some(yk_stored) = yubikey {
                     // We found two YubiKeys, so we won't use either.
                     // Don't reset them.
-                    let _ = yk_stored.disconnect(pcsc::Disposition::LeaveCard);
-                    let _ = yk_found.disconnect(pcsc::Disposition::LeaveCard);
+                    let _ = yk_stored.disconnect(Disposition::LeaveCard);
+                    let _ = yk_found.disconnect(Disposition::LeaveCard);
 
                     error!("multiple YubiKeys detected!");
                     return Err(Error::PcscError { inner: None });
@@ -243,7 +243,7 @@ impl YubiKey {
                 return Ok(yubikey);
             } else {
                 // We didn't want this YubiKey; don't reset it.
-                let _ = yubikey.disconnect(pcsc::Disposition::LeaveCard);
+                let _ = yubikey.disconnect(Disposition::LeaveCard);
             }
         }
 
@@ -263,7 +263,7 @@ impl YubiKey {
         self.card.reconnect(
             pcsc::ShareMode::Shared,
             pcsc::Protocols::T1,
-            pcsc::Disposition::ResetCard,
+            Disposition::ResetCard,
         )?;
 
         let pin = self
@@ -373,7 +373,11 @@ impl YubiKey {
 
         let mut data = Vec::with_capacity(4 + challenge_len + 2 + challenge_len);
         data.push(TAG_DYN_AUTH);
-        data.push((2 + challenge_len + 2 + challenge_len).try_into().unwrap());
+        data.push(
+            (2 + challenge_len + 2 + challenge_len)
+                .try_into()
+                .expect("value fits in u8"),
+        );
         data.push(0x80);
         data.push(challenge_len as u8);
         data.extend_from_slice(&card_challenge);
@@ -672,7 +676,7 @@ impl<'a> TryFrom<&'a Reader<'_>> for YubiKey {
                 // a side-effect of determining this. Avoid disrupting its internal state
                 // any further (e.g. preserve the PIN cache of whatever applet is selected
                 // currently).
-                if let Err((_, e)) = card.disconnect(pcsc::Disposition::LeaveCard) {
+                if let Err((_, e)) = card.disconnect(Disposition::LeaveCard) {
                     error!("Failed to disconnect gracefully from card: {}", e);
                 }
 

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -363,7 +363,7 @@ impl YubiKey {
             .data([TAG_DYN_AUTH, 0x02, 0x80, 0x00])
             .transmit(&txn, 261)?;
 
-        if !card_response.is_success() {
+        if !card_response.is_success() || card_response.data().len() < 5 {
             return Err(Error::AuthenticationError);
         }
 

--- a/src/yubikey.rs
+++ b/src/yubikey.rs
@@ -36,7 +36,7 @@ use crate::{
     chuid::ChuId,
     config::Config,
     error::{Error, Result},
-    mgm::MgmKey,
+    mgm::{MgmKey, MgmKeyAlgorithm},
     piv,
     reader::{Context, Reader},
     transaction::Transaction,
@@ -357,37 +357,39 @@ impl YubiKey {
     }
 
     /// Authenticate to the card using the provided management key (MGM).
-    pub fn authenticate(&mut self, mgm_key: MgmKey) -> Result<()> {
+    pub fn authenticate<C: MgmKeyAlgorithm>(&mut self, mgm_key: MgmKey<C>) -> Result<()> {
         let txn = self.begin_transaction()?;
 
         // get a challenge from the card
-        let challenge = Apdu::new(Ins::Authenticate)
-            .params(ALGO_3DES, KEY_CARDMGM)
+        let card_response = Apdu::new(Ins::Authenticate)
+            .params(mgm_key.algorithm_id(), KEY_CARDMGM)
             .data([TAG_DYN_AUTH, 0x02, 0x80, 0x00])
             .transmit(&txn, 261)?;
 
-        if !challenge.is_success() || challenge.data().len() < 12 {
+        if !card_response.is_success() {
             return Err(Error::AuthenticationError);
         }
 
         // send a response to the cards challenge and a challenge of our own.
-        let response = mgm_key.decrypt(challenge.data()[4..12].try_into()?);
+        let card_challenge = mgm_key.card_challenge(&card_response.data()[4..])?;
+        let challenge_len = card_challenge.len();
 
-        let mut data = [0u8; 22];
-        data[0] = TAG_DYN_AUTH;
-        data[1] = 20; // 2 + 8 + 2 +8
-        data[2] = 0x80;
-        data[3] = 8;
-        data[4..12].copy_from_slice(&response);
-        data[12] = 0x81;
-        data[13] = 8;
-        OsRng.fill_bytes(&mut data[14..22]);
+        let mut data = Vec::with_capacity(4 + challenge_len + 2 + challenge_len);
+        data.push(TAG_DYN_AUTH);
+        data.push((2 + challenge_len + 2 + challenge_len).try_into().unwrap());
+        data.push(0x80);
+        data.push(challenge_len as u8);
+        data.extend_from_slice(&card_challenge);
+        data.push(0x81);
+        data.push(challenge_len as u8);
 
-        let mut challenge = [0u8; 8];
-        challenge.copy_from_slice(&data[14..22]);
+        let mut host_challenge = vec![0u8; challenge_len];
+        OsRng.fill_bytes(&mut host_challenge);
+
+        data.extend_from_slice(&host_challenge);
 
         let authentication = Apdu::new(Ins::Authenticate)
-            .params(ALGO_3DES, KEY_CARDMGM)
+            .params(mgm_key.algorithm_id(), KEY_CARDMGM)
             .data(data)
             .transmit(&txn, 261)?;
 
@@ -396,14 +398,7 @@ impl YubiKey {
         }
 
         // compare the response from the card with our challenge
-        let response = mgm_key.encrypt(&challenge);
-
-        use subtle::ConstantTimeEq;
-        if response.ct_eq(&authentication.data()[4..12]).unwrap_u8() != 1 {
-            return Err(Error::AuthenticationError);
-        }
-
-        Ok(())
+        mgm_key.check_challenge(&host_challenge, &authentication.data()[4..])
     }
 
     /// Get the PIV keys contained in this YubiKey.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -16,7 +16,8 @@ use yubikey::{
     certificate::yubikey_signer,
     certificate::Certificate,
     piv::{self, AlgorithmId, Key, ManagementSlotId, RetiredSlotId, SlotId},
-    Error, MgmKey, PinPolicy, Serial, TouchPolicy, YubiKey,
+    Error, MgmKey, MgmKey3Des, MgmKeyAes128, MgmKeyAes192, MgmKeyAes256, MgmKeyAlgorithm,
+    PinPolicy, Serial, TouchPolicy, YubiKey,
 };
 
 static YUBIKEY: Lazy<Mutex<YubiKey>> = Lazy::new(|| {
@@ -108,6 +109,26 @@ fn test_verify_pin() {
     assert!(yubikey.verify_pin(b"123456").is_ok());
 }
 
+fn get_mgm_key_meta(yubikey: &mut YubiKey) -> piv::SlotMetadata {
+    piv::metadata(yubikey, SlotId::Management(ManagementSlotId::Management)).unwrap()
+}
+
+/// Given a default YubiKey, authenticate with the default management key.
+/// 
+/// This is slightly complicated by newer firmwares using AES192 as the MGM default key,
+/// over 3DES.
+fn auth_default_mgm(yubikey: &mut YubiKey) {
+    match get_mgm_key_meta(yubikey).algorithm {
+        piv::ManagementAlgorithmId::ThreeDes => {
+            assert!(yubikey.authenticate(MgmKey3Des::default()).is_ok())
+        }
+        piv::ManagementAlgorithmId::Aes192 => {
+            assert!(yubikey.authenticate(MgmKeyAes192::default()).is_ok())
+        }
+        other => panic!("unexpected management key algorithm: {:?}", other),
+    }
+}
+
 //
 // Management key support
 //
@@ -119,29 +140,41 @@ fn test_set_mgmkey() {
     let mut yubikey = YUBIKEY.lock().unwrap();
 
     assert!(yubikey.verify_pin(b"123456").is_ok());
-    assert!(MgmKey::get_protected(&mut yubikey).is_err());
-    assert!(yubikey.authenticate(MgmKey::default()).is_ok());
 
-    // Set a protected management key.
-    assert!(MgmKey::generate().set_protected(&mut yubikey).is_ok());
-    let protected = MgmKey::get_protected(&mut yubikey).unwrap();
-    assert!(yubikey.authenticate(MgmKey::default()).is_err());
-    assert!(yubikey.authenticate(protected.clone()).is_ok());
+    fn test_mgm<M: MgmKeyAlgorithm>(yubikey: &mut YubiKey) {
+        assert!(yubikey.authenticate::<M>(MgmKey::default::<M>()).is_ok());
+        assert!(MgmKey::<M>::get_protected(yubikey).is_err());
 
-    // Set a manual management key.
-    let manual = MgmKey::generate();
-    assert!(manual.set_manual(&mut yubikey, false).is_ok());
-    assert!(MgmKey::get_protected(&mut yubikey).is_err());
-    assert!(yubikey.authenticate(MgmKey::default()).is_err());
-    assert!(yubikey.authenticate(protected.clone()).is_err());
-    assert!(yubikey.authenticate(manual.clone()).is_ok());
+        // Set a protected management key.
+        assert!(MgmKey::generate::<M>().set_protected(yubikey).is_ok());
+        let protected = MgmKey::get_protected::<M>(yubikey).unwrap();
+        assert!(yubikey.authenticate::<M>(MgmKey::default::<M>()).is_err());
+        assert!(yubikey.authenticate(protected.clone()).is_ok());
 
-    // Set back to the default management key.
-    assert!(MgmKey::set_default(&mut yubikey).is_ok());
-    assert!(MgmKey::get_protected(&mut yubikey).is_err());
-    assert!(yubikey.authenticate(protected).is_err());
-    assert!(yubikey.authenticate(manual).is_err());
-    assert!(yubikey.authenticate(MgmKey::default()).is_ok());
+        // Set a manual management key.
+        let manual = MgmKey::<M>::generate();
+        assert!(manual.set_manual(&mut yubikey, false).is_ok());
+        assert!(MgmKey::<M>::get_protected(&mut yubikey).is_err());
+        assert!(yubikey.authenticate(MgmKey::<M>::default()).is_err());
+        assert!(yubikey.authenticate(protected.clone()).is_err());
+        assert!(yubikey.authenticate(manual.clone()).is_ok());
+
+        // Set back to the default management key.
+        assert!(MgmKey::<M>::set_default(&mut yubikey).is_ok());
+        assert!(MgmKey::<M>::get_protected(&mut yubikey).is_err());
+        assert!(yubikey.authenticate(protected).is_err());
+        assert!(yubikey.authenticate(manual).is_err());
+        assert!(yubikey.authenticate(MgmKey::<M>::default()).is_ok());
+    }
+
+    match get_mgm_admin(&mut yubikey).algorithm {
+        ManagementAlgorithmId::ThreeDes => test_mgm::<des::TdesEee3>(&mut yubikey),
+        ManagementAlgorithmId::Aes192 => test_mgm::<aes::Aes192>(&mut yubikey),
+        ManagementAlgorithmId::Aes128 | ManagementAlgorithmId::Aes192 => {
+            panic!("AES128 or AES256 should not be a default key")
+        }
+        other => panic!("unexpected management key algorithm: {:?}", other),
+    }
 }
 
 //
@@ -152,11 +185,10 @@ fn generate_self_signed_cert<KT: yubikey_signer::KeyType>() -> Certificate {
     let mut yubikey = YUBIKEY.lock().unwrap();
 
     assert!(yubikey.verify_pin(b"123456").is_ok());
-    assert!(yubikey.authenticate(MgmKey::default()).is_ok());
+    auth_default_mgm(&mut yubikey);
 
     let slot = SlotId::Retired(RetiredSlotId::R1);
 
-    // Generate a new key in the selected slot.
     let generated = piv::generate(
         &mut yubikey,
         slot,
@@ -289,7 +321,7 @@ fn test_read_metadata() {
     let mut yubikey = YUBIKEY.lock().unwrap();
 
     assert!(yubikey.verify_pin(b"123456").is_ok());
-    assert!(yubikey.authenticate(MgmKey::default()).is_ok());
+    auth_default_mgm(&mut yubikey);
 
     let slot = SlotId::Retired(RetiredSlotId::R1);
 


### PR DESCRIPTION
This follows the conversation in #330 using a trait-based approach.

I bumped into this while building tools to program new yubikeys where they default to AES192 as the default algorithm.

As such, I figured it was time to add the support in.

Thoughts?