### PR TITLE
Bump MSRV to 1.81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
             toolchain: stable
             deps: true
           - platform: ubuntu-latest
-            toolchain: 1.74.0 # MSRV
+            toolchain: 1.81.0 # MSRV
             deps: sudo apt-get install libpcsclite-dev
           - platform: windows-latest
-            toolchain: 1.74.0 # MSRV
+            toolchain: 1.81.0 # MSRV
             deps: true
           - platform: macos-latest
-            toolchain: 1.74.0 # MSRV
+            toolchain: 1.81.0 # MSRV
             deps: true
     runs-on: ${{ matrix.platform }}
     steps:
@@ -82,7 +82,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.74.0 # MSRV
+          toolchain: 1.81.0 # MSRV
           components: clippy
           override: true
       - run: sudo apt-get install libpcsclite-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- MSRV is now 1.81.
+
 ## 0.8.0 (2023-08-15)
 ### Added
 - `impl Debug for {Context, YubiKey}` ([#457])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 categories = ["api-bindings", "authentication", "cryptography", "hardware-support"]
 keywords = ["ecdsa", "encryption", "rsa", "piv", "signature"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.81"
 
 [workspace]
 members = [".", "cli"]

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ or conditions.
 [docs-link]: https://docs.rs/yubikey/
 [license-image]: https://img.shields.io/badge/license-BSD-blue.svg
 [license-link]: https://github.com/iqlusioninc/yubikey.rs/blob/main/COPYING
-[msrv-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.81+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/yubikey.rs/workflows/CI/badge.svg?branch=main&event=push

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- MSRV is now 1.81.
+
 ## 0.7.0 (2022-11-14)
 ### Changed
 - Bump `clap` to v4.0 ([#438])

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 categories = ["command-line-utilities", "cryptography", "hardware-support"]
 keywords = ["ecdsa", "rsa", "piv", "pcsc", "yubikey"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.81"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -196,7 +196,7 @@ pub fn print_cert_info(
     print_cert_attr(
         stream,
         "Fingerprint",
-        &hex::upper::encode_string(&fingerprint),
+        hex::upper::encode_string(&fingerprint),
     )?;
     print_cert_attr(
         stream,

--- a/src/error.rs
+++ b/src/error.rs
@@ -192,8 +192,8 @@ impl std::error::Error for Error {
     }
 }
 
-impl From<x509_cert::der::Error> for Error {
-    fn from(_err: x509_cert::der::Error) -> Error {
+impl From<der::Error> for Error {
+    fn from(_err: der::Error) -> Error {
         Error::ParseError
     }
 }

--- a/src/msroots.rs
+++ b/src/msroots.rs
@@ -96,10 +96,9 @@ impl MsRoots {
             }
         }
 
-        MsRoots::new(&data).map(Some).map_err(|e| {
-            error!("error parsing msroots: {:?}", e);
-            e
-        })
+        MsRoots::new(&data)
+            .map(Some)
+            .inspect_err(|e| error!("error parsing msroots: {:?}", e))
     }
 
     /// Write `msroots` file to YubiKey

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -66,10 +66,7 @@ impl<'tx> Transaction<'tx> {
             .p1(0x04)
             .data(piv::APPLET_ID)
             .transmit(self, 0xFF)
-            .map_err(|e| {
-                error!("failed communicating with card: '{}'", e);
-                e
-            })?;
+            .inspect_err(|e| error!("failed communicating with card: '{}'", e))?;
 
         if !response.is_success() {
             error!(
@@ -335,10 +332,7 @@ impl<'tx> Transaction<'tx> {
 
         let response = self
             .transfer_data(&templ, &indata[..offset], 1024)
-            .map_err(|e| {
-                error!("sign command failed to communicate: {}", e);
-                e
-            })?;
+            .inspect_err(|e| error!("sign command failed to communicate: {}", e))?;
 
         if !response.is_success() {
             error!("failed sign command with code {:x}", response.code());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,9 +12,7 @@ use signature::hazmat::PrehashVerifier;
 use std::{env, str::FromStr, sync::Mutex, time::Duration};
 use x509_cert::{der::Encode, name::Name, serial_number::SerialNumber, time::Validity};
 use yubikey::{
-    certificate,
-    certificate::yubikey_signer,
-    certificate::Certificate,
+    certificate::{yubikey_signer, Certificate},
     piv::{self, AlgorithmId, Key, ManagementSlotId, RetiredSlotId, SlotId},
     Error, MgmKey, PinPolicy, Serial, TouchPolicy, YubiKey,
 };
@@ -317,8 +315,7 @@ fn test_read_metadata() {
 #[ignore]
 fn test_parse_cert_from_der() {
     let bob_der = std::fs::read("tests/assets/Bob.der").expect(".der file not found");
-    let cert =
-        certificate::Certificate::from_bytes(bob_der).expect("Failed to parse valid certificate");
+    let cert = Certificate::from_bytes(bob_der).expect("Failed to parse valid certificate");
     assert_eq!(
         cert.subject(),
         "CN=Bob",


### PR DESCRIPTION
This is required due to the `hybrid-array` crate, which has become a transitive dependency of the majority of our dependencies and will be required in the very near future.