### PR TITLE
support nitrokey 3

### DIFF
--- a/src/piv.rs
+++ b/src/piv.rs
@@ -78,7 +78,9 @@ use zeroize::Zeroizing;
 pub(crate) const APPLET_NAME: &str = "PIV";
 
 /// PIV Applet ID
-pub(crate) const APPLET_ID: &[u8] = &[0xa0, 0x00, 0x00, 0x03, 0x08];
+pub(crate) const APPLET_ID: &[u8] = &[
+    0xa0, 0x00, 0x00, 0x03, 0x08, 0x00, 0x00, 0x10, 0x00, 0x01, 0x00,
+];
 
 const CB_ECC_POINTP256: usize = 65;
 const CB_ECC_POINTP384: usize = 97;


### PR DESCRIPTION
not sure whether this is in the scope of this library, but with the [nitrokey 3 firmware 1.8.0](https://github.com/Nitrokey/nitrokey-3-firmware/releases/tag/v1.8.0) it now supports a piv applet as well and it'd be nice to reuse this library for the nitrokey 3 as well.

supporting the key required two (probably minor) changes:
- the piv applet's aid uses the full aid as specified in [nist sp 800-73-4](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf) section 2.2 instead of just the nist prefix. yubikeys seem to support both the prefix (which is technically against the spec) and the full aid (tested with a yubikey 5c nfc), while the nitrokey 3 requires the full aid.
- the nitrokey 3, for some strange reason, does not return any data on the select application apdu, instead returning a bytes remaining response and requiring a separate get response call to return the actual data.

the nitrokey 3 also currently uses a static version (6.6.6) and serial (0x0052f743, 5437251), but supports the same commands as the yubikey 5.