### PR TITLE
add support for rsa3072 and rsa4096

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.0"
 description = """
 Pure Rust cross-platform host-side driver for YubiKey devices from Yubico with
 support for hardware-backed public-key decryption and digital signatures using
-the Personal Identity Verification (PIV) application. Supports RSA (1024/2048)
+the Personal Identity Verification (PIV) application. Supports RSA (1024/2048/3072/4096)
 or ECC (NIST P-256/P-384) algorithms e.g, PKCS#1v1.5, ECDSA
 """
 authors = ["Tony Arcieri <tony@iqlusion.io>", "Yubico AB"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ access provided by the [`pcsc` crate].
 ## About
 
 YubiKeys are versatile devices and through their PIV support, you can use them
-to store a number of RSA (2048/1024) and ECC (NIST P-256/P-384) private keys
+to store a number of RSA (1024/2048/3072/4096) and ECC (NIST P-256/P-384) private keys
 with configurable access control policies. Both the signing (RSASSA/ECDSA) and
 encryption (PKCS#1v1.5/ECIES) use cases are supported for either key type.
 
@@ -56,13 +56,16 @@ on which devices support PIV and the available functionality.
 ### Supported Algorithms
 - **Authentication**: `3DES`
 - **Encryption**:
-  - RSA: `RSA1024`, `RSA2048`
+  - RSA: `RSA1024`, `RSA2048`, `RSA3072`, `RSA4096`
   - ECC: `ECCP256`, `ECCP384` (NIST curves: P-256, P-384)
 - **Signatures**:
-  - RSASSA-PKCS#1v1.5: `RSA1024`, `RSA2048`
+  - RSASSA-PKCS#1v1.5: `RSA1024`, `RSA2048`, `RSA3072`, `RSA4096`
   - ECDSA: `ECCP256`, `ECCP384` (NIST curves: P-256, P-384)
 
-NOTE: RSASSA-PSS signatures and RSA-OAEP encryption may be supportable (TBD)
+NOTE:
+
+- RSASSA-PSS signatures and RSA-OAEP encryption may be supportable (TBD)
+- `RSA3072` and `RSA4096` require a YubiKey with firmware 5.7 or newer.
 
 ## Minimum Supported Rust Version
 

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -369,6 +369,22 @@ pub mod yubikey_signer {
         const ALGORITHM: AlgorithmId = AlgorithmId::Rsa2048;
     }
 
+    /// RSA 3072 bits key
+    pub struct Rsa3072;
+
+    impl RsaLength for Rsa3072 {
+        const BIT_LENGTH: usize = 3072;
+        const ALGORITHM: AlgorithmId = AlgorithmId::Rsa3072;
+    }
+
+    /// RSA 4096 bits key
+    pub struct Rsa4096;
+
+    impl RsaLength for Rsa4096 {
+        const BIT_LENGTH: usize = 4096;
+        const ALGORITHM: AlgorithmId = AlgorithmId::Rsa4096;
+    }
+
     /// RSA keys used to sign certificates
     pub struct YubiRsa<N: RsaLength> {
         _len: PhantomData<N>,

--- a/src/piv.rs
+++ b/src/piv.rs
@@ -545,7 +545,10 @@ impl AlgorithmId {
     #[cfg(feature = "untested")]
     fn get_param_tag(self) -> u8 {
         match self {
-            AlgorithmId::Rsa1024 | AlgorithmId::Rsa2048 | AlgorithmId::Rsa3072 | AlgorithmId::Rsa4096 => 0x01,
+            AlgorithmId::Rsa1024
+            | AlgorithmId::Rsa2048
+            | AlgorithmId::Rsa3072
+            | AlgorithmId::Rsa4096 => 0x01,
             AlgorithmId::EccP256 | AlgorithmId::EccP384 => 0x6,
         }
     }
@@ -618,7 +621,10 @@ pub fn generate(
     let setting_roca: setting::Setting;
 
     match algorithm {
-        AlgorithmId::Rsa1024 | AlgorithmId::Rsa2048 | AlgorithmId::Rsa3072 | AlgorithmId::Rsa4096 => {
+        AlgorithmId::Rsa1024
+        | AlgorithmId::Rsa2048
+        | AlgorithmId::Rsa3072
+        | AlgorithmId::Rsa4096 => {
             if yubikey.version.major == 4
                 && (yubikey.version.minor < 3
                     || yubikey.version.minor == 3 && (yubikey.version.patch < 5))
@@ -833,7 +839,10 @@ pub fn import_rsa_key(
     pin_policy: PinPolicy,
 ) -> Result<()> {
     match algorithm {
-        AlgorithmId::Rsa1024 | AlgorithmId::Rsa2048 | AlgorithmId::Rsa3072 | AlgorithmId::Rsa4096 => (),
+        AlgorithmId::Rsa1024
+        | AlgorithmId::Rsa2048
+        | AlgorithmId::Rsa3072
+        | AlgorithmId::Rsa4096 => (),
         _ => return Err(Error::AlgorithmError),
     }
 
@@ -1123,7 +1132,10 @@ fn read_public_key(
     //
     //    0x7f 0x49 -> Application | Constructed | 0x49
     match algorithm {
-        AlgorithmId::Rsa1024 | AlgorithmId::Rsa2048 | AlgorithmId::Rsa3072 | AlgorithmId::Rsa4096=> {
+        AlgorithmId::Rsa1024
+        | AlgorithmId::Rsa2048
+        | AlgorithmId::Rsa3072
+        | AlgorithmId::Rsa4096 => {
             // It appears that the inner application-specific value returned by the
             // YubiKey is constructed such that RSA pubkeys can be parsed in two ways:
             //

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -281,22 +281,22 @@ impl<'tx> Transaction<'tx> {
         let templ = [0, Ins::Authenticate.code(), algorithm.into(), key.into()];
 
         match algorithm {
-            AlgorithmId::Rsa1024  => {
+            AlgorithmId::Rsa1024 => {
                 if in_len != 128 {
                     return Err(Error::SizeError);
                 }
             }
-            AlgorithmId::Rsa2048  => {
+            AlgorithmId::Rsa2048 => {
                 if in_len != 256 {
                     return Err(Error::SizeError);
                 }
             }
-            AlgorithmId::Rsa3072  => {
+            AlgorithmId::Rsa3072 => {
                 if in_len != 384 {
                     return Err(Error::SizeError);
                 }
             }
-            AlgorithmId::Rsa4096  => {
+            AlgorithmId::Rsa4096 => {
                 if in_len != 512 {
                     return Err(Error::SizeError);
                 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -281,14 +281,23 @@ impl<'tx> Transaction<'tx> {
         let templ = [0, Ins::Authenticate.code(), algorithm.into(), key.into()];
 
         match algorithm {
-            AlgorithmId::Rsa1024 | AlgorithmId::Rsa2048 => {
-                let key_len = if let AlgorithmId::Rsa1024 = algorithm {
-                    128
-                } else {
-                    256
-                };
-
-                if in_len != key_len {
+            AlgorithmId::Rsa1024  => {
+                if in_len != 128 {
+                    return Err(Error::SizeError);
+                }
+            }
+            AlgorithmId::Rsa2048  => {
+                if in_len != 256 {
+                    return Err(Error::SizeError);
+                }
+            }
+            AlgorithmId::Rsa3072  => {
+                if in_len != 384 {
+                    return Err(Error::SizeError);
+                }
+            }
+            AlgorithmId::Rsa4096  => {
+                if in_len != 512 {
                     return Err(Error::SizeError);
                 }
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -229,8 +229,11 @@ fn generate_rsa3072() {
     );
 
     match generated {
-        Ok(key) => { let pubkey = key.subject_public_key; assert!(pubkey.bit_len() > 3072) },
-        Err(e)  => assert!( (version.major,version.minor) < (5,7) && e == Error::AlgorithmError),
+        Ok(key) => {
+            let pubkey = key.subject_public_key;
+            assert!(pubkey.bit_len() > 3072)
+        }
+        Err(e) => assert!((version.major, version.minor) < (5, 7) && e == Error::AlgorithmError),
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -211,6 +211,31 @@ fn generate_self_signed_rsa_cert() {
 
 #[test]
 #[ignore]
+fn generate_rsa3072() {
+    let mut yubikey = YUBIKEY.lock().unwrap();
+    let version = yubikey.version();
+
+    assert!(yubikey.authenticate(MgmKey::default()).is_ok());
+
+    let slot = SlotId::Retired(RetiredSlotId::R1);
+
+    // Generate a new key in the selected slot.
+    let generated = piv::generate(
+        &mut yubikey,
+        slot,
+        AlgorithmId::Rsa3072,
+        PinPolicy::Default,
+        TouchPolicy::Default,
+    );
+
+    match generated {
+        Ok(key) => { let pubkey = key.subject_public_key; assert!(pubkey.bit_len() > 3072) },
+        Err(e)  => assert!( (version.major,version.minor) < (5,7) && e == Error::AlgorithmError),
+    }
+}
+
+#[test]
+#[ignore]
 fn generate_self_signed_ec_cert() {
     let cert = generate_self_signed_cert::<p256::NistP256>();
 


### PR DESCRIPTION
Adding support for larger RSA key sizes for YubiKeys with firmware version 5.7 and newer.
Note that newer YubiKeys come with an AES default management key. 
Until this crate supports AES management keys (See #589) you will need to first set your YubiKeys management key to TDES:

    ykman piv access change-management-key -a TDES -n 010203040506070801020304050607080102030405060708