### PR TITLE
chore(deps): bump `nom` from `7.1.3` to `8.0.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,19 +434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ des = "0.9.0-rc.0"
 elliptic-curve = "0.14.0-rc.7"
 hex = { package = "base16ct", version = "0.2", features = ["alloc"] }
 log = "0.4"
-nom = "7"
+nom = "8"
 ecdsa = { version = "0.17.0-rc.2", features = ["digest", "pem"] }
 p256 = "=0.14.0-pre.9"
 p384 = "=0.14.0-pre.9"

--- a/src/mgm.rs
+++ b/src/mgm.rs
@@ -663,6 +663,7 @@ impl DeviceInfo {
             combinator::{eof, map},
             multi::fold_many1,
             number::complete::{be_u16, be_u32, u8},
+            Parser,
         };
 
         fn u8_parser(i: &[u8]) -> nom::IResult<&[u8], u8> {
@@ -679,13 +680,13 @@ impl DeviceInfo {
         }
 
         fn capability_parser(i: &[u8]) -> nom::IResult<&[u8], Capability> {
-            let (i, v) = map(be_u16, Capability::from_bits_retain)(i)?;
+            let (i, v) = map(be_u16, Capability::from_bits_retain).parse(i)?;
             let (i, _) = eof(i)?;
 
             Ok((i, v))
         }
         fn serial_parser(i: &[u8]) -> nom::IResult<&[u8], Serial> {
-            let (i, v) = map(be_u32, Serial)(i)?;
+            let (i, v) = map(be_u32, Serial).parse(i)?;
             let (i, _) = eof(i)?;
 
             Ok((i, v))
@@ -792,7 +793,8 @@ impl DeviceInfo {
                 }
                 err => err,
             },
-        )(rest)
+        )
+        .parse(rest)
         .map_err(|_: nom::Err<()>| Error::ParseError)?
         .1?;
 
@@ -880,9 +882,10 @@ impl DeviceFlags {
         use nom::{
             combinator::{eof, map},
             number::complete::u8,
+            Parser,
         };
 
-        let (i, v) = map(u8, Self::from_bits_retain)(i)?;
+        let (i, v) = map(u8, Self::from_bits_retain).parse(i)?;
         let (i, _) = eof(i)?;
 
         Ok((i, v))

--- a/src/piv.rs
+++ b/src/piv.rs
@@ -981,6 +981,7 @@ impl TryFrom<Buffer> for SlotMetadata {
             combinator::{eof, map_res},
             multi::fold_many1,
             number::complete::u8,
+            Parser,
         };
 
         let out = fold_many1(
@@ -1005,8 +1006,8 @@ impl TryFrom<Buffer> for SlotMetadata {
                         fn policy_parser(
                             i: &[u8],
                         ) -> nom::IResult<&[u8], (PinPolicy, TouchPolicy)> {
-                            let (i, pin) = map_res(u8, PinPolicy::try_from)(i)?;
-                            let (i, touch) = map_res(u8, TouchPolicy::try_from)(i)?;
+                            let (i, pin) = map_res(u8, PinPolicy::try_from).parse(i)?;
+                            let (i, touch) = map_res(u8, TouchPolicy::try_from).parse(i)?;
                             let (i, _) = eof(i)?;
 
                             Ok((i, (pin, touch)))
@@ -1018,7 +1019,7 @@ impl TryFrom<Buffer> for SlotMetadata {
                     }
                     3 => {
                         fn origin_parser(i: &[u8]) -> nom::IResult<&[u8], Origin> {
-                            let (i, origin) = map_res(u8, Origin::try_from)(i)?;
+                            let (i, origin) = map_res(u8, Origin::try_from).parse(i)?;
                             let (i, _) = eof(i)?;
 
                             Ok((i, origin))
@@ -1078,7 +1079,8 @@ impl TryFrom<Buffer> for SlotMetadata {
                 },
                 err => err,
             },
-        )(buf.as_ref());
+        )
+        .parse(buf.as_ref());
 
         match out {
             Ok((_, res)) => res,


### PR DESCRIPTION
supersedes https://github.com/iqlusioninc/yubikey.rs/pull/597

Fixes #597