### PR TITLE
dependabot: perform consolidated lockfile updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,19 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: '13:00'
-  open-pull-requests-limit: 10
+  - package-ecosystem: cargo
+    versioning-strategy: lockfile-only
+    directory: "/"
+    allow:
+      - dependency-type: "all"
+    groups:
+      all-deps:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Update all dependencies in Cargo.lock, rather than opening individual PRs for each of them