### PR TITLE
change algorithm_id to pub from pub(crate)

### DIFF
--- a/src/mgm.rs
+++ b/src/mgm.rs
@@ -457,7 +457,7 @@ impl MgmKey {
     }
 
     /// Returns the ID used to identify the key algorithm with APDU packets.
-    pub(crate) fn algorithm_id(&self) -> MgmAlgorithmId {
+    pub fn algorithm_id(&self) -> MgmAlgorithmId {
         match &self.0 {
             MgmKeyKind::Tdes(_) => MgmAlgorithmId::ThreeDes,
             MgmKeyKind::Aes128(_) => MgmAlgorithmId::Aes128,


### PR DESCRIPTION
This changes visibility of the algorithm ID for the management keys to allow gating usage of some features (like RSA key sizes) in apps that support current and older YubiKeys. 